### PR TITLE
Support for DEFAULT_FILE_STORAGE

### DIFF
--- a/feincms/module/medialibrary/models.py
+++ b/feincms/module/medialibrary/models.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from django.contrib import admin
 from django.contrib.auth.decorators import permission_required
 from django.conf import settings as django_settings
+from django.core.urlresolvers import get_callable
 from django.db import models
 from django.template.defaultfilters import filesizeformat
 from django.utils.safestring import mark_safe
@@ -76,9 +77,12 @@ class CategoryAdmin(admin.ModelAdmin):
 # ------------------------------------------------------------------------
 class MediaFileBase(Base, TranslatedObjectMixin):
 
-    # XXX maybe have a look at settings.DEFAULT_FILE_STORAGE here?
     from django.core.files.storage import FileSystemStorage
-    fs = FileSystemStorage(location=settings.FEINCMS_MEDIALIBRARY_ROOT,
+    default_storage_class = getattr(django_settings, 'DEFAULT_FILE_STORAGE', 
+                                    'django.core.files.storage.FileSystemStorage')
+    default_storage = get_callable(default_storage_class)
+        
+    fs = default_storage(location=settings.FEINCMS_MEDIALIBRARY_ROOT,
                            base_url=settings.FEINCMS_MEDIALIBRARY_URL)
 
     file = models.FileField(_('file'), max_length=255, upload_to=settings.FEINCMS_MEDIALIBRARY_UPLOAD_TO, storage=fs)


### PR DESCRIPTION
Hey mk, 

Here's a small update to the medialibrary so it supports de DEFAULT_FILE_STORAGE setting from django. My commit author name and email got (another time) unfortunatley messed around because of evil koalas. it seems i cannot revert them on git-hub anymore, even if i do a filter-branch locally an then repush that stuff... maybe we shall try on monday?
