### PR TITLE
Make ApplicationContent urls swappable/more granular

### DIFF
--- a/feincms/content/application/models.py
+++ b/feincms/content/application/models.py
@@ -275,11 +275,14 @@ class ApplicationContent(models.Model):
         else:
             path = re.sub('^' + re.escape(page_url[:-1]), '', request.path)
 
+        # Resolve the module holding the application urls.
+        urlconf_path = self.config.get('urls', self.urlconf_path)
+        
         # Change the prefix and urlconf for the monkey-patched reverse function ...
-        _local.urlconf = (self.urlconf_path, page_url)
+        _local.urlconf = (urlconf_path, page_url)
 
         try:
-            fn, args, kwargs = resolve(path, self.urlconf_path)
+            fn, args, kwargs = resolve(path, urlconf_path)
         except (ValueError, Resolver404):
             del _local.urlconf
             raise Resolver404


### PR DESCRIPTION
Hi

I ran into an issue changing the url module for application contents. The url 
module is saved to database making it impossible to move the module around without
updating the database. This patch adds possibility to move url modules around.

Say I register a blog like this:

```
Page.create_content_type(ApplicationContent, APPLICATIONS=(
    ('cms.urls', 'Blog'),
))
```

But later split up the urls modules in separate files, I'll pass in a custom config
parameter:

```
Page.create_content_type(ApplicationContent, APPLICATIONS=(
    ('cms.urls', 'Blog', {'urls': 'cms.blog.urls'}),
))
```

Saves updating the database.

Also, using the first parameter strictly as choice key seems nicer. 

```
Page.create_content_type(ApplicationContent, APPLICATIONS=(
    ('cms.blog', 'Blog', {'urls': 'cms.blog.urls'}),
    ('cms.gallery', 'Gallery', {'urls': 'cms.gallery.urls'}),
))
```
