### PR TITLE
Fixed TINYMCE_JS_URL

### DIFF
--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -22,7 +22,7 @@ FEINCMS_MEDIALIBRARY_URL = getattr(settings, 'FEINCMS_MEDIALIBRARY_URL', setting
 # Settings for RichText
 FEINCMS_TINYMCE_INIT_TEMPLATE = 'admin/content/richtext/init_tinymce.html'
 FEINCMS_TINYMCE_INIT_CONTEXT  = {
-    'TINYMCE_JS_URL': join(settings.MEDIA_URL, 'js/tiny_mce/tiny_mce.js'),
+    'TINYMCE_JS_URL': getattr(settings, 'TINYMCE_JS_URL', join(settings.MEDIA_URL, 'js/tiny_mce/tiny_mce.js')),
     'TINYMCE_CONTENT_CSS_URL': None,
     'TINYMCE_LINK_LIST_URL': None
 }


### PR DESCRIPTION
I noticed that the documentation said you can set the TINYMCE_JS_URL to change tinymce js url, unfortunately your code didn't allow it to be changed.

'TINYMCE_JS_URL': join(settings.MEDIA_URL, 'js/tiny_mce/tiny_mce.js'),

it should be something like this:

'TINYMCE_JS_URL': getattr(settings, 'TINYMCE_JS_URL', join(settings.MEDIA_URL, 'js/tiny_mce/tiny_mce.js')),

CMIIW.

Thanks.
