### PR TITLE
Add support for TINYMCE_INIT_INSTANCE_CALLBACK setting

### DIFF
--- a/feincms/templates/admin/content/richtext/init_tinymce.html
+++ b/feincms/templates/admin/content/richtext/init_tinymce.html
@@ -23,6 +23,7 @@
         height: '300',
         {% if TINYMCE_CONTENT_CSS_URL %}content_css: "{{ TINYMCE_CONTENT_CSS_URL }}",{% endif %}
         {% if TINYMCE_LINK_LIST_URL %}external_link_list_url: "{{ TINYMCE_LINK_LIST_URL }}",{% endif %}
+        {% if TINYMCE_INIT_INSTANCE_CALLBACK %}init_instance_callback: "{{TINYMCE_INIT_INSTANCE_CALLBACK}}",{% endif %}
         plugins: "{% block plugins %}fullscreen,paste{% endblock %}",
         paste_auto_cleanup_on_paste: true,
         relative_urls: false


### PR DESCRIPTION
Straightforward commit: this adds an extra supported parameter to the FEINCMS_RICHTEXT_INIT_CONTEXT dict.

My motivation for this is to be able to specify a function which will apply different stylings to different tinymce instances. In particular, I have a content-type which includes two different richtext fields - I want them to have different heights. Rather than putting different params into the tinymce init args, I can specify a callback to change the heights afterwards.
