### PR TITLE
Fix for compatibility with django-debug-toolbar

### DIFF
--- a/feincms/views/base.py
+++ b/feincms/views/base.py
@@ -96,6 +96,14 @@ class Handler(object):
             add_never_cache_headers(response)
 
         return response
+    
+    @property
+    def __name__(self):
+        """
+        Dummy property to make this handler behave like a normal function.
+        This property is used by django-debug-toolbar
+        """
+        return self.__class__.__name__
 
 #: Default handler
 handler = Handler()


### PR DESCRIPTION
add property **name** to view Handler to imitate standard function behaviour
used by django-debug-toolbar: https://github.com/robhudson/django-debug-toolbar/blob/master/debug_toolbar/panels/request_vars.py#L35
