### PR TITLE
More control over the content type inlines used in the admin

### DIFF
--- a/feincms/admin/item_editor.py
+++ b/feincms/admin/item_editor.py
@@ -59,7 +59,7 @@ def get_feincms_inlines(model):
             'form': getattr(content_type, 'feincms_item_editor_form',
                             ItemEditorForm),
             }
-        inlines.append(type(name, (FeinCMSInline,), attrs))
+        inlines.append(type(name, (getattr(content_type, 'feincms_item_editor_admin_model', FeinCMSInline),), attrs))
     return inlines
 
 


### PR DESCRIPTION
Allow the inline ModelAdmin to be used for ContentTypes to be overriden by a property on the abstract model
This allows for more fine tuned changes to the inlines next to the form option.

We needed to limit a foreign key on a content type based on the current user and found we where unable to do that without also extending the **init** method of the ModelAdmin for the model the content type was attached to.
