### PR TITLE
Remove medialibrary dependency on local file system based storage.

### DIFF
--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -697,8 +697,6 @@ class PageAdminForm(forms.ModelForm):
         # See the comment below on why we do not use Page.objects.active(),
         # at least for now.
         active_pages = Page.objects.filter(active=True)
-        if hasattr(Page, 'site'):
-            active_pages = active_pages.filter(site=cleaned_data['site'])
 
         if self.instance:
             current_id = self.instance.id


### PR DESCRIPTION
We encountered a couple of problems when using the medialibrary app with a file system other than the default django.core.files.storage.FileSystemStorage.

When using storages.backends.s3.S3Storage from django-storages MediaFileBase raised an error because it was trying to initialise S3Storage with the kwargs "location" and "base_url". S3Storage is a remote storage using Amazons S3 storage so has no concept of base_url.

We fixed the issue by catching the exception and initialising the storage with no arguments. In addition the S3Storage does not implement the path property.
