### PR TITLE
Bugfix: The TINYMCE settings from the django project were ignored in feincms.

### DIFF
--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -28,9 +28,11 @@ FEINCMS_MEDIALIBRARY_URL = getattr(settings, 'FEINCMS_MEDIALIBRARY_URL', setting
 # Settings for RichText
 FEINCMS_TINYMCE_INIT_TEMPLATE = 'admin/content/richtext/init_tinymce.html'
 FEINCMS_TINYMCE_INIT_CONTEXT  = {
-    'TINYMCE_JS_URL': join(settings.MEDIA_URL, 'js/tiny_mce/tiny_mce.js'),
-    'TINYMCE_CONTENT_CSS_URL': None,
-    'TINYMCE_LINK_LIST_URL': None
+    'TINYMCE_JS_URL': getattr(settings, 'TINYMCE_JS_URL', join(settings.MEDIA_URL,
+        'js/tiny_mce/tiny_mce.js')),
+    'TINYMCE_CONTENT_CSS_URL': getattr(settings, 'TINYMCE_CONTENT_CSS_URL', None),
+    'TINYMCE_LINK_LIST_URL': getattr(settings, 'TINYMCE_LINK_LIST_URL', None),
+
 }
 
 FEINCMS_RICHTEXT_INIT_TEMPLATE = getattr(settings, 'FEINCMS_RICHTEXT_INIT_TEMPLATE', FEINCMS_TINYMCE_INIT_TEMPLATE)


### PR DESCRIPTION
According to the docs if the user wants to enable TinyMCE for editing rich content he has to define the `TINYMCE_JS_URL` setting variable and make it point to the URL of the main TinyMCE js file. This variable (as well as the other variables in `FEINCMS_TINYMCE_INIT_CONTEXT`) turns out to be **ignored** in the definition of  `FEINCMS_TINYMCE_INIT_CONTEXT` in the `default_settingys.py` file. This commit fixes this.
