### PR TITLE
Removing dependancies on local filesystem storage

### DIFF
--- a/feincms/module/medialibrary/models.py
+++ b/feincms/module/medialibrary/models.py
@@ -317,11 +317,6 @@ class MediaFileTranslation(Translation(MediaFile)):
 def admin_thumbnail(obj):
 
     if obj.type == 'image':
-        # feincms_thumbnail.thumbnail only works for local filesystem storage (indicated by availability the path property)
-        try:
-            obj.file.path
-        except NotImplementedError:
-            return ''
         image = None
         try:
             image = feincms_thumbnail.thumbnail(obj.file.name, '100x100')


### PR DESCRIPTION
Updated medialibrary to track original_file_name (rather than path) to determine if old files should be deleted when the file is changed. Also updated it to delete "old" files using the file's storage.

Using get_image_dimensions is expensive and very slow when using the S3 remote storage so I removed this from MediaFileBase.file_type when the storage is not the local filesystem. I better approach might be to store this information in the database.

Updated the thumbnail template filter to use the default_storage rather than "os". In the case of the S3 remote storage it is not possible to get the files modification time (to determine when the thumbnail should be re generated ). The thumbnail will only generate the thumbnails when they do not exist. I believe other thumbnailers (like sorl-thumbnail) use a database table to store the time information.
