### PR TITLE
Make medialibrary optional

### DIFF
--- a/feincms/templates/admin/feincms/_content_type_buttons.html
+++ b/feincms/templates/admin/feincms/_content_type_buttons.html
@@ -13,21 +13,21 @@ var CONTENT_TYPE_BUTTONS = [
         type: 'mediafilecontent',
         keep: true,
         cssclass: 'imagecontent',
-        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist %}?type__exact=image&pop=1'
+        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist as media_library_url %}{{ media_library_url }}?type__exact=image&pop=1'
     }, {
         type: 'gallerycontent'
     }, {
         type: 'mediafilecontent',
         keep: true,
         cssclass: 'pdfcontent',
-        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist %}?type__exact=pdf&pop=1'
+        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist as media_library_url %}{{ media_library_url }}%}?type__exact=pdf&pop=1'
     }, {
         type: 'oembedcontent'
     }, {
         type: 'mediafilecontent',
         keep: true,
         cssclass: 'audiocontent',
-        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist %}?type__exact=audio&pop=1'
+        raw_id_picker: '{% url admin:medialibrary_mediafile_changelist as media_library_url %}{{ media_library_url }}%}?type__exact=audio&pop=1'
     }
 ];
 </script>


### PR DESCRIPTION
Avoid NoReverseMatch exception when the FeinCMS media library isn't installed

Commit f79424d62a9d3cbd3829e6369423d92f56503a3e made the medialibrary mandatory, since it tries to reverse the URLs therein. This commit uses the "safe" version of the {% url %} templatetag. It shouldn't matter if the returned URL is empty, since in that case it doesn't get used at all.
