### PR TITLE
PageSitemap

### DIFF
--- a/feincms/module/page/sitemap.py
+++ b/feincms/module/page/sitemap.py
@@ -13,7 +13,7 @@ class PageSitemap(Sitemap):
     The PageSitemap can be used to automatically generate sitemap.xml files
     for submission to index engines. See http://www.sitemaps.org/ for details.
     """
-    def __init__(self, navigation_only=False, max_depth=0, changefreq=None, queryset=None, filter=None, *args, **kwargs):
+    def __init__(self, navigation_only=False, max_depth=0, changefreq=None, queryset=None, filter=None, extended_navigation=False, *args, **kwargs):
         """
         The PageSitemap accepts the following parameters for customisation
         of the resulting sitemap.xml output:
@@ -28,16 +28,20 @@ class PageSitemap(Sitemap):
         in the site map.
         * filter -- pass in a callable that transforms a queryset to filter
         out the pages you want to include in the site map.
+        * extended_navigation -- if set to True, adds pages from any navigation
+        extensions. If using PagePretender, make sure to include title, url,
+        level, in_navigation and optionally modification_date.
         """
         super(PageSitemap, self).__init__(*args, **kwargs)
-        self.depth_cutoff    = max_depth
-        self.navigation_only = navigation_only
-        self.changefreq      = changefreq
-        self.filter          = filter
+        self.depth_cutoff        = max_depth
+        self.navigation_only     = navigation_only
+        self.changefreq          = changefreq
+        self.filter              = filter
+        self.extended_navigation = extended_navigation
         if queryset is not None:
-            self.queryset    = queryset
+            self.queryset        = queryset
         else:
-            self.queryset    = Page.objects.active()
+            self.queryset        = Page.objects.active()
 
     def items(self):
         """
@@ -62,7 +66,15 @@ class PageSitemap(Sitemap):
         if self.depth_cutoff > 0:
             qs = qs.filter(level__lte=self.max_depth-1)
 
-        return [ p for p in qs if p.is_active() ]
+        pages = [ p for p in qs if p.is_active() ]
+        
+        if self.extended_navigation:
+            for idx, page in enumerate(pages):
+                if getattr(page, 'navigation_extension', None):
+                    pages[idx + 1:idx + 1] = page.extended_navigation()
+        
+        return pages
+        
 
     def lastmod(self, obj):
         return getattr(obj, 'modification_date', None)


### PR DESCRIPTION
Added the ability to display extended navigation items for 3rd party applications in the sitemap.xml. There are a few notes:
- Because enabling this functionality could break an existing sitemap, I added a new paramater into the PageSitemap function and defaulted it to False. The reason it might break is if you were to use PagePretender without the required fields listed.
- In order to get this to work, I had to make sure my get_absolute_url function included the urls/name, i.e. 'blog_urls/blog_details' otherwise the reverse lookup wouldn't work.
- I am seeing an issue where if I assign the same third party app to multiple pages, the first page is the only one listed in the sitemap.xml so if I had /news/ and /more_news/, the urls always reverse as /news/. This looks like it may be an issue with the way the feincms reverse function works, or possibly can be fixed just by passing some extra information into extended_navigation().
