### PR TITLE
Hello, here is minor fix to match recent Django changes

### DIFF
--- a/feincms/admin/item_editor.py
+++ b/feincms/admin/item_editor.py
@@ -61,15 +61,24 @@ class ItemEditor(admin.ModelAdmin):
         ensure_completely_loaded()
 
         super(ItemEditor, self).__init__(model, admin_site)
+
+        if hasattr(self, 'inline_instances'):
+            # Add inline instances for FeinCMS content inlines
+            # This works in Django 1.3 and lower
+            # In Django 1.4 inline instances are generated using overridden get_inline_instances()
+            self.append_feincms_inlines(self.inline_instances)
     
     def get_inline_instances(self, request):
         inline_instances = super(ItemEditor, self).get_inline_instances(request)
+        self.append_feincms_inlines(inline_instances)
         
+        return inline_instances
+    
+    def append_feincms_inlines(self, inline_instances):
+        """ Append generated FeinCMS content inlines to native django inlines. """
         for inline_class in self.get_feincms_inlines(self.model):
             inline_instance = inline_class(self.model, self.admin_site)
             inline_instances.append(inline_instance)
-        
-        return inline_instances
 
     def get_feincms_inlines(self, model):
         """ Generate genuine django inlines for registered content types. """


### PR DESCRIPTION
Moved inline instances generating into appropriate inherited method. Old behaviour is broken due to the recent changes in Django.
See https://github.com/django/django/commit/d297bc7b9da8e929e781e708234777d98348476a#django/contrib/admin/options.py
