### PR TITLE
there was an error in the queryset transformation for translation lookup

### DIFF
--- a/feincms/translations.py
+++ b/feincms/translations.py
@@ -114,7 +114,7 @@ def lookup_translations(language_code=None):
         if instance_dict:
             _process(candidates, instance_dict, settings.LANGUAGE_CODE, 'istartswith')
         if instance_dict:
-            for candidate in candidates.filter(pk__in=instance_dict.keys()):
+            for candidate in candidates.filter(parent__pk__in=instance_dict.keys()):
                 if candidate.parent_id in instance_dict:
                     _found(instance_dict, candidate)
 
@@ -131,7 +131,7 @@ def lookup_translations(language_code=None):
 
     def _process(candidates, instance_dict, lang_, op_):
         for candidate in candidates.filter(
-                Q(pk__in=instance_dict.keys()),
+                Q(parent__pk__in=instance_dict.keys()),
                 Q(**{'language_code__' + op_: lang_})
                 | Q(**{'language_code__' + op_: short_language_code(lang_)})
                 ).order_by('-language_code'):


### PR DESCRIPTION
bevore this patch it was searching for translations with pk = pk from the translated object. it should search on the foreignkey field instead, but it didn't work with parent_id__in=... because django didn't recognize the field. so i used parent__pk__in=

this results in the following sql query using a sqlite database (example from a recent project):
SELECT "catalog_producttranslation"."id", "catalog_producttranslation"."parent_id", "catalog_producttranslation"."language_code", "catalog_producttranslation"."name", "catalog_producttranslation"."short_description", "catalog_producttranslation"."description" FROM "catalog_producttranslation" WHERE ("catalog_producttranslation"."parent_id" IN (8192, 8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8204, 8205, 8207, 8209, 8210, 8211, 8212, 8214, 8215, 8216, 8217, 8218) AND ("catalog_producttranslation"."language_code" LIKE de ESCAPE '\' OR "catalog_producttranslation"."language_code" LIKE de ESCAPE '\' )) ORDER BY "catalog_producttranslation"."language_code" DESC

and it finds all translations in the first attempt now
