### PR TITLE
python 2.5 doesn't allow relative imports with *

### DIFF
--- a/feincms/urls.py
+++ b/feincms/urls.py
@@ -1,4 +1,4 @@
 
 from __future__ import absolute_import
 
-from .views.cbv.urls import *
+from feincms.views.cbv.urls import *


### PR DESCRIPTION
using python 2.5 feincms 1.5 wasn't even installable, this commit should fix this and hopefully not break something else.
