### PR TITLE
Improve default for the `FEINCMS_ADMIN_MEDIA` setting.

### DIFF
--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -35,7 +35,7 @@ FEINCMS_RICHTEXT_INIT_CONTEXT = getattr(settings, 'FEINCMS_RICHTEXT_INIT_CONTEXT
 # Admin media settings
 
 #: Path to FeinCMS' admin media
-FEINCMS_ADMIN_MEDIA = getattr(settings, 'FEINCMS_ADMIN_MEDIA', '/static/feincms/')
+FEINCMS_ADMIN_MEDIA = getattr(settings, 'FEINCMS_ADMIN_MEDIA', settings.STATIC_URL + 'feincms/')
 #: Link to google APIs instead of using local copy of JS libraries
 FEINCMS_ADMIN_MEDIA_HOTLINKING = getattr(settings, 'FEINCMS_ADMIN_MEDIA_HOTLINKING', False)
 #: avoid jQuery conflicts -- scripts should use feincms.jQuery instead of $


### PR DESCRIPTION
It should fall back to appending to `settings.STATIC_URL` instead of assuming `/static/`
