### PR TITLE
Added ``FEINCMS_USE_REVERSION``.

### DIFF
--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -94,3 +94,6 @@ FEINCMS_TIDY_SHOW_WARNINGS = getattr(settings, 'FEINCMS_TIDY_SHOW_WARNINGS', Tru
 FEINCMS_TIDY_ALLOW_WARNINGS_OVERRIDE = getattr(settings, 'FEINCMS_TIDY_ALLOW_WARNINGS_OVERRIDE', True)
 #: Name of the tidy function - anything which takes (html) and returns (html, errors, warnings) can be used:
 FEINCMS_TIDY_FUNCTION = getattr(settings, 'FEINCMS_TIDY_FUNCTION', 'feincms.utils.html.tidy.tidy_html')
+
+#: If True, use django-reversion with FeinCMS
+FEINCMS_USE_REVERSION = True

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -11,6 +11,8 @@ import warnings
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings as django_settings
+
 from django.db import connection, models
 from django.db.models import Q
 from django.db.models.fields import FieldDoesNotExist
@@ -24,10 +26,8 @@ from django.utils.translation import ugettext_lazy as _
 from feincms import settings, ensure_completely_loaded
 from feincms.utils import get_object, copy_model_instance
 
-try:
+if (settings.FEINCMS_USE_REVERSION and 'reversion' in django_settings.INSTALLED_APPS):
     import reversion
-except ImportError:
-    reversion = None
 
 try:
     any


### PR DESCRIPTION
django-reversion will be used if FEINCMS_USE_REVERSION is True (default)
and if reversion is in INSTALLED_APPS.

This fixes an issue with deleteing content types whe reversion is on a
python path, but is not installed in django project.
