### PR TITLE
Updated add_view and change_view to reflect change_view signature change

### DIFF
--- a/feincms/admin/item_editor.py
+++ b/feincms/admin/item_editor.py
@@ -198,7 +198,7 @@ class ItemEditor(admin.ModelAdmin):
 
         return extra_context
 
-    def add_view(self, request, form_url='', extra_context=None):
+    def add_view(self, request, **kwargs):
         context = {}
 
         # insert dummy object as 'original' so template code can grab defaults
@@ -213,10 +213,11 @@ class ItemEditor(admin.ModelAdmin):
             context['original'].template_key = request.POST['template_key']
 
         context.update(self.get_extra_context(request))
-        context.update(extra_context or {})
-        return super(ItemEditor, self).add_view(request, form_url, extra_context=context)
+        context.update(kwargs.get('extra_context', {}))
+        kwargs['extra_context'] = context
+        return super(ItemEditor, self).add_view(request, **kwargs)
 
-    def change_view(self, request, object_id, extra_context=None):
+    def change_view(self, request, object_id, **kwargs):
         # Recognize frontend editing requests
         # This is done here so that the developer does not need to add
         # additional entries to # urls.py or something...
@@ -227,8 +228,9 @@ class ItemEditor(admin.ModelAdmin):
 
         context = {}
         context.update(self.get_extra_context(request))
-        context.update(extra_context or {})
-        return super(ItemEditor, self).change_view(request, object_id, extra_context=context)
+        context.update(kwargs.get('extra_context', {}))
+        kwargs['extra_context'] = context
+        return super(ItemEditor, self).change_view(request, object_id, **kwargs)
 
     # The next two add support for sending a "saving done" signal as soon
     # as all relevant data have been saved (especially all foreign key relations)

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -622,12 +622,10 @@ class PageAdmin(item_editor.ItemEditor, tree_editor.TreeEditor):
 
         return actions
 
-    def add_view(self, request, form_url='', extra_context=None):
+    def add_view(self, request, **kwargs):
         # Preserve GET parameters
-        return super(PageAdmin, self).add_view(
-            request=request,
-            form_url=request.get_full_path(),
-            extra_context=extra_context)
+        kwargs['form_url'] = request.get_full_path()
+        return super(PageAdmin, self).add_view(request, **kwargs)
 
     def response_add(self, request, obj, *args, **kwargs):
         response = super(PageAdmin, self).response_add(request, obj, *args, **kwargs)
@@ -657,9 +655,9 @@ class PageAdmin(item_editor.ItemEditor, tree_editor.TreeEditor):
     def _refresh_changelist_caches(self, *args, **kwargs):
         self._visible_pages = list(self.model.objects.active().values_list('id', flat=True))
 
-    def change_view(self, request, object_id, extra_context=None):
+    def change_view(self, request, object_id, **kwargs):
         try:
-            return super(PageAdmin, self).change_view(request, object_id, extra_context)
+            return super(PageAdmin, self).change_view(request, object_id, **kwargs)
         except PermissionDenied:
             from django.contrib import messages
             messages.add_message(request, messages.ERROR, _("You don't have the necessary permissions to edit this object"))


### PR DESCRIPTION
... in Django 1.4b. This should work in the future if signatures changes again.

Use of kwargs only (without args) should be safe, because admin views are called using keyword arguments.
