### PR TITLE
_tree_manager attribute is wrong

### DIFF
--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -366,13 +366,18 @@ class TreeEditor(admin.ModelAdmin):
         return r and super(TreeEditor, self).has_delete_permission(request, obj)
 
     def _move_node(self, request):
-        cut_item = self.model.objects.get(pk=request.POST.get('cut_item'))
-        pasted_on = self.model.objects.get(pk=request.POST.get('pasted_on'))
+        if hasattr(self.model.objects, 'move_node'):
+            tree_manager = self.model.objects
+        else:
+            tree_manager = self.model._tree_manager
+
+        cut_item = tree_manager.get(pk=request.POST.get('cut_item'))
+        pasted_on = tree_manager.get(pk=request.POST.get('pasted_on'))
         position = request.POST.get('position')
 
         if position in ('last-child', 'left'):
             try:
-                self.model.objects.move_node(cut_item, pasted_on, position)
+                tree_manager.move_node(cut_item, pasted_on, position)
             except InvalidMove, e:
                 self.message_user(request, unicode(e))
                 return HttpResponse('FAIL')


### PR DESCRIPTION
In my project I need to implement my own `move_node` method on TreeManager. I created my mptt model MyMpttModel and set `MyMpttModel.objects` to my own MyTreeManager that has its `move_node` implementation.

But I can't really get what I want because admin's TreeEditor._move_node uses model attribute '_tree_manager' that references original TreeManager but not MyTreeManager.

According to documentation `objects` is now a default name for mptt models managers as stated here http://django-mptt.github.com/django-mptt/upgrade.html#treemanager-is-now-the-default-manager-yourmodel-tree-removed
