### PR TITLE
Easy way to activate ext, tpls and ct of page modules in settings.py

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -67,6 +67,37 @@ Please note that you should put these statements into a ``models.py`` file
 which is executed at Django startup time, i.e. into a ``models.py`` file
 contained in ``INSTALLED_APPS``.
 
+Also you can use a more django way to put all your extensions, templates and
+content types initialzation in project's ``settings.py`` via
+``FEINCMS_PAGE_EXTENSIONS``, ``FEINCMS_PAGE_TEMPLATES`` and
+``FEINCMS_PAGE_CONTENTS``. The codes below is a same example as above::
+
+    from django.utils.translation import ugettext_lazy as _
+
+    FEINCMS_PAGE_EXTENSIONS = (
+        'datepublisher',
+        'translation',
+    )
+
+    FEINCMS_PAGE_TEMPLATES = ({
+        'title': _('Standard template'),
+        'path': 'base.html',
+        'regions': (
+            ('main', _('Main content area')),
+            ('sidebar', _('Sidebar'), 'inherited'),
+            ),
+        }
+    )
+
+    FEINCMS_PAGE_CONTENTS = (
+        {'model': 'feincms.content.richtext.models.RichTextContent'},
+        {'model': 'feincms.content.medialibrary.v2.MediaFileContent',
+            'TYPE_CHOICES': (
+                ('lightbox', _('lightbox')),
+                ('download', _('as download'))
+            )
+        }
+    )
 
 Setting up the admin interface
 ==============================

--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -114,3 +114,7 @@ FEINCMS_CMS_404_PAGE = getattr(settings, 'FEINCMS_CMS_404_PAGE', None)
 FEINCMS_MEDIAFILE_OVERWRITE = getattr(settings, 'FEINCMS_MEDIAFILE_OVERWRITE', False)
 
 # ------------------------------------------------------------------------
+# Make page activation in settings.py
+FEINCMS_PAGE_EXTENSIONS = getattr(settings, 'FEINCMS_PAGE_EXTENSIONS', None)
+FEINCMS_PAGE_TEMPLATES  = getattr(settings, 'FEINCMS_PAGE_TEMPLATES',  None)
+FEINCMS_PAGE_CONTENTS   = getattr(settings, 'FEINCMS_PAGE_CONTENTS',   None)

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -583,6 +583,23 @@ def create_base_model(inherit_from=models.Model):
                 cls.feincms_item_editor_includes = {}
 
         @classmethod
+        def create_content_types(cls, *contents):
+            for content in contents:
+                if isinstance(content['model'], basestring):
+                    try:
+                        content['model'] = get_object(content['model'])
+                    except ImportError:
+                        raise ImproperlyConfigured, '%s is not a valid \
+                            content type' % content['model']
+                    cls.create_content_type(**content)
+                else:
+                    try:
+                        cls.create_content_type(**content)
+                    except:
+                        raise ImproperlyConfigured, 'Your configuration for \
+                            FEINCMS_PAGE_CONTENTS is invalid!'
+
+        @classmethod
         def create_content_type(cls, model, regions=None, class_name=None, **kwargs):
             """
             This is the method you'll use to create concrete content types.

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -695,4 +695,16 @@ class PageAdmin(item_editor.ItemEditor, tree_editor.TreeEditor):
     is_visible_admin.editable_boolean_result = is_visible_recursive
 
 # ------------------------------------------------------------------------
-# ------------------------------------------------------------------------
+# initial loading extensions, templates and content types of page
+
+if settings.FEINCMS_PAGE_EXTENSIONS:
+    Page.register_extensions(*settings.FEINCMS_PAGE_EXTENSIONS)
+
+if settings.FEINCMS_PAGE_TEMPLATES:
+    Page.register_templates(*settings.FEINCMS_PAGE_TEMPLATES)
+
+if settings.FEINCMS_PAGE_CONTENTS:
+    Page.create_content_types(*settings.FEINCMS_PAGE_CONTENTS)
+
+# -------------------------------------------------------------------------
+# -------------------------------------------------------------------------


### PR DESCRIPTION
To new django users like me, I got confused when I setup feincms the first time because settings.py is I used to manage. So I believe using FEINCMS_PAGE_EXTENSIONS, FEINCMS_PAGE_TEMPLATES and FEINCMS_PAGE_CONTENTS to initialize functions of page module will be easier and more directly to new feincms users.

just doing like this in settings.py:

```
from django.utils.translation import ugettext_lazy as _

FEINCMS_PAGE_EXTENSIONS = (
    'datepublisher',
    'translation',
)

FEINCMS_PAGE_TEMPLATES = ({
    'title': _('Standard template'),
    'path': 'base.html',
    'regions': (
        ('main', _('Main content area')),
        ('sidebar', _('Sidebar'), 'inherited'),
        ),
    }
)

FEINCMS_PAGE_CONTENTS = (
    {'model': 'feincms.content.richtext.models.RichTextContent'},
    {'model': 'feincms.content.medialibrary.v2.MediaFileContent',
        'TYPE_CHOICES': (
            ('lightbox', _('lightbox')),
            ('download', _('as download'))
        )
    }
)
```
