### PR TITLE
_frontend_editing_view needs context_instance

### DIFF
--- a/feincms/admin/item_editor.py
+++ b/feincms/admin/item_editor.py
@@ -153,7 +153,7 @@ class ItemEditor(admin.ModelAdmin):
                     'identifier': obj.fe_identifier(),
                     'FEINCMS_JQUERY_NO_CONFLICT': \
                         settings.FEINCMS_JQUERY_NO_CONFLICT,
-                    })
+                    }, context_instance=template.RequestContext(request))
         else:
             form = ModelForm(instance=obj, prefix=content_type)
 


### PR DESCRIPTION
I found a bug whilst enabling the front-end editing feature, the `_frontend_editing_view` function didn't use `RequestContext` so the javascript didn't work as expected.
