### PR TITLE
fix #228 Per-site caching does not work...

### DIFF
--- a/feincms/module/page/processors.py
+++ b/feincms/module/page/processors.py
@@ -30,10 +30,11 @@ def frontendediting_request_processor(page, request):
         except ValueError:
             enable_fe = False
 
-        request.session['frontend_editing'] = enable_fe
+    response = HttpResponseRedirect(request.path)
+    response.set_cookie('frontend_editing', enable_fe)
 
     # Redirect to cleanup URLs
-    return HttpResponseRedirect(request.path)
+    return response
 
 
 def etag_request_processor(page, request):

--- a/feincms/templatetags/feincms_tags.py
+++ b/feincms/templatetags/feincms_tags.py
@@ -19,9 +19,10 @@ def _render_content(content, **kwargs):
             return
         setattr(request, 'feincms_render_level', level + 1)
 
-    try:
+    if (request and request.COOKIES.get('frontend_editing', False) and\
+            hasattr(content, 'fe_render')):
         r = content.fe_render(**kwargs)
-    except AttributeError:
+    else:
         r = content.render(**kwargs)
 
     if request is not None:

--- a/feincms/views/cbv/views.py
+++ b/feincms/views/cbv/views.py
@@ -87,7 +87,7 @@ class HandlerBase(TemplateView):
         self.page.finalize_response(self.request, response)
 
         # Add never cache headers in case frontend editing is active
-        if hasattr(self.request, "session") and self.request.session.get('frontend_editing', False):
+        if hasattr(self.request, "COOKIES") and self.request.COOKIES.get('frontend_editing', False):
             add_never_cache_headers(response)
 
         return response


### PR DESCRIPTION
Avoid forced Vary: Cookie header that is added when session is accessed.
Use cookie instead of session for frontend_editing.
