### PR TITLE
Deprecate shorthand notation when registering extensions

### DIFF
--- a/example/models.py
+++ b/example/models.py
@@ -70,9 +70,10 @@ class BlogEntriesNavigationExtension(NavigationExtension):
                 level=page.level + 1,
                 )
 
-Page.register_extensions('navigation')
-Page.register_extensions('sites')
-
+Page.register_extensions(
+    'feincms.module.page.extensions.navigation',
+    'feincms.module.page.extensions.sites',
+    )
 
 
 class Category(MPTTModel):

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -309,6 +309,13 @@ class ExtensionsMixin(object):
                         try:
                             fn = get_object('%s.%s.register' % (path, ext))
                             if fn:
+                                warnings.warn(
+                                    'Using short names for extensions has been deprecated'
+                                    ' and will be removed in FeinCMS v1.8.'
+                                    ' Please provide the full python path to the extension'
+                                    ' %s instead (%s.%s).' % (ext, path, ext),
+                                    DeprecationWarning, stacklevel=2)
+
                                 break
                         except ImportError:
                             pass


### PR DESCRIPTION
`Page.register_extensions('navigation')` is fragile and non-obvious. We should be using `Page.register_extensions('feincms.module.page.extensions.navigation')` instead to make it clear where the code comes from.

(Django is doing the same all the time, for example with the `DATABASES` configuration where the `BACKEND` has to be specified with the full python module path now.)
