### PR TITLE
Administration: deleting content elements fixed

### DIFF
--- a/feincms/static/feincms/item_editor.js
+++ b/feincms/static/feincms/item_editor.js
@@ -394,7 +394,7 @@ if(!Array.indexOf) {
                         set_item_field_value(item,"delete-field","checked");
                     }
                     item.fadeOut(200, function() {
-                      region_item = $("#"+REGION_MAP[ACTIVE_REGION]+"_body");
+                      var region_item = $("#"+REGION_MAP[ACTIVE_REGION]+"_body");
                       if (region_item.children("div.order-machine").children(":visible").length == 0) {
                           region_item.children("div.empty-machine-msg").show();
                       }


### PR DESCRIPTION
After deleting all content elements of a region, the empty region message will be displayed and new added content elements are displayed correctly. Before that, the elements were empty.
