### PR TITLE
Avoid error for unbound local variable in tag

### DIFF
--- a/feincms/templatetags/applicationcontent_tags.py
+++ b/feincms/templatetags/applicationcontent_tags.py
@@ -58,6 +58,7 @@ class AppReverseNode(template.Node):
         except NoReverseMatch:
             if self.asvar is None:
                 raise
+            url = ''
 
         if self.asvar:
             context[self.asvar] = url


### PR DESCRIPTION
In case of unresolvable URLs with asvar given, the templatetag bails with an UnboundLocalError four lines later.
