### PR TITLE
Vimeo flash embed player was deprecated.

### DIFF
--- a/feincms/templates/content/video/vimeo.html
+++ b/feincms/templates/content/video/vimeo.html
@@ -1,6 +1,2 @@
-<object width="650" height="365">
-    <param name="allowfullscreen" value="true" />
-    <param name="allowscriptaccess" value="always" />
-    <param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id={{ id }}&amp;server=vimeo.com&amp;show_title=1&amp;show_byline=1&amp;show_portrait=0&amp;color=&amp;fullscreen=1" />
-    <embed src="http://vimeo.com/moogaloop.swf?clip_id={{ id }}&amp;server=vimeo.com&amp;show_title=1&amp;show_byline=1&amp;show_portrait=0&amp;color=&amp;fullscreen=1" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="650" height="365"></embed>
-</object>
+<iframe src="http://player.vimeo.com/video/{{ id }}" width="650" height="365"
+frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>


### PR DESCRIPTION
Updated to the new embed code for Vimeo.
See: http://developer.vimeo.com/player/embedding for more information.
I've kept the dimensions the same as with the deprecated megaloop player.
