### PR TITLE
ensure_completely_loaded is forced when new content_types are registered.

### DIFF
--- a/feincms/__init__.py
+++ b/feincms/__init__.py
@@ -23,7 +23,7 @@ settings = LazySettings()
 
 
 COMPLETELY_LOADED = False
-def ensure_completely_loaded():
+def ensure_completely_loaded(force=False):
     """
     This method ensures all models are completely loaded
 
@@ -36,7 +36,7 @@ def ensure_completely_loaded():
     """
 
     global COMPLETELY_LOADED
-    if COMPLETELY_LOADED:
+    if COMPLETELY_LOADED and not force:
         return True
 
     # Ensure meta information concerning related fields is up-to-date.

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -729,6 +729,7 @@ def create_base_model(inherit_from=models.Model):
                 for key, includes in model.feincms_item_editor_includes.items():
                     cls.feincms_item_editor_includes.setdefault(key, set()).update(includes)
 
+            ensure_completely_loaded(force=True)
             return new_type
 
         @property


### PR DESCRIPTION
Adding a 'force' parameter to ensure_completely_loaded, and a forced call when a content_type is added. See #323
