### PR TITLE
Only doing minimal cache building when registering a content_type.

### DIFF
--- a/feincms/__init__.py
+++ b/feincms/__init__.py
@@ -23,7 +23,7 @@ settings = LazySettings()
 
 
 COMPLETELY_LOADED = False
-def ensure_completely_loaded(force=False):
+def ensure_completely_loaded():
     """
     This method ensures all models are completely loaded
 
@@ -36,7 +36,7 @@ def ensure_completely_loaded(force=False):
     """
 
     global COMPLETELY_LOADED
-    if COMPLETELY_LOADED and not force:
+    if COMPLETELY_LOADED:
         return True
 
     # Ensure meta information concerning related fields is up-to-date.

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -729,7 +729,10 @@ def create_base_model(inherit_from=models.Model):
                 for key, includes in model.feincms_item_editor_includes.items():
                     cls.feincms_item_editor_includes.setdefault(key, set()).update(includes)
 
-            ensure_completely_loaded(force=True)
+            # since this content type is potentially being added after cls is
+            # loaded by Django, we will reload the cls's related objects cache.
+            # See issue #323.
+            cls._meta._fill_related_objects_cache()
             return new_type
 
         @property


### PR DESCRIPTION
Last patch re #323 was a sledgehammer to crack a walnut. This is a leaner solution.
