### PR TITLE
only process fieldset if they are not customized

### DIFF
--- a/feincms/templatetags/feincms_admin_tags.py
+++ b/feincms/templatetags/feincms_admin_tags.py
@@ -13,6 +13,9 @@ def post_process_fieldsets(fieldset):
     Additionally, it ensures that dynamically added fields (i.e.
     ``ApplicationContent``'s ``admin_fields`` option) are shown.
     """
+    # abort if fieldset is customized
+    if fieldset.model_admin.fieldsets:
+        return fieldset
 
     fields_to_include = set(fieldset.form.fields.keys())
     for f in ('id', 'DELETE', 'ORDER'):


### PR DESCRIPTION
This solves the problem of displaying all fields for every fieldset in a FeinCMS Inline.
