### PR TITLE
Check that short_title is really callable

### DIFF
--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -225,7 +225,7 @@ class TreeEditor(ExtensionModelAdmin):
         r += '<span id="page_marker-%d" class="page_marker%s" style="width: %dpx;">&nbsp;</span>&nbsp;' % (
                 item.pk, editable_class, 14+getattr(item, mptt_opts.level_attr)*18)
 #        r += '<span tabindex="0">'
-        if hasattr(item, 'short_title'):
+        if hasattr(item, 'short_title') and callable(item.short_title):
             r += escape(item.short_title())
         else:
             r += escape(unicode(item))


### PR DESCRIPTION
The `TreeEditor` for mptt models is very nice, but it will raise an exception if the `short_title` on the model it's being used for is a field and not a callable. So, we should check first.
