### PR TITLE
Fix error when using datepublisher extension

### DIFF
--- a/feincms/module/extensions/datepublisher.py
+++ b/feincms/module/extensions/datepublisher.py
@@ -110,7 +110,7 @@ def register(cls, admin_cls):
     admin_cls.list_display.insert(pos + 1, 'datepublisher_admin')
 
     admin_cls.add_extension_options(_('Date-based publishing'), {
-                'fields': ('publication_date', 'publication_end_date'),
+                'fields': ['publication_date', 'publication_end_date'],
         })
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
In some cases, when datepublisher extension is used an another extension tries to modify the admin, it's crashes because datepublisher returned a tuple.
