### PR TITLE
Updated models.py -> invalidate_cache()

### DIFF
--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -287,6 +287,8 @@ class BasePage(create_base_model(MPTTModel), ContentModelMixin):
     def invalidate_cache(self):
         ck = self.path_to_cache_key(self._original_cached_url)
         django_cache.delete(ck)
+        ck = self.path_to_cache_key(self._cached_url)
+        django_cache.delete(ck)
 
     @models.permalink
     def get_absolute_url(self):


### PR DESCRIPTION
A problem occurs when using `best_match_for_path()` if the desired path does not already exist at creation time.  On first run, `best_match_for_path()` will populate the cache with the best possible match.  When the user creates the actual desired path however, the cache is never updated as the code only flushes `_original_cached_url` (which is empty for a new page).

This is resolved by _also_ flushing `_cached_url` at the same time.
