### PR TITLE
Fix PageAdmin.add_view

### DIFF
--- a/feincms/module/page/modeladmins.py
+++ b/feincms/module/page/modeladmins.py
@@ -123,7 +123,7 @@ class PageAdmin(item_editor.ItemEditor, tree_editor.TreeEditor):
                 kwargs['extra_context'] = {
                     'adding_translation': True,
                     'title': _(
-                        'Add %(language)s Translation of "%(page)s"' % {
+                        u'Add %(language)s Translation of "%(page)s"' % {
                             'language': language,
                             'page': original,
                         }


### PR DESCRIPTION
Fix PageAdmin.add_view: title should be a Unicode string otherwise ugettext will raise UnicodeDecodeError when 'language' or 'page.title' is not in ASCII.
