### PR TITLE
Use Django generic class-based views instead of function-based views

### DIFF
--- a/feincms/views/generic/create_update.py
+++ b/feincms/views/generic/create_update.py
@@ -1,7 +1,7 @@
-from django.views.generic import create_update
+from django.views.generic import CreateView, UpdateView, DeleteView
 from feincms.views.decorators import add_page_to_extra_context
 
 
-create_object = add_page_to_extra_context(create_update.create_object)
-update_object = add_page_to_extra_context(create_update.update_object)
-delete_object = add_page_to_extra_context(create_update.delete_object)
+create_object = add_page_to_extra_context(CreateView.as_view())
+update_object = add_page_to_extra_context(UpdateView.as_view())
+delete_object = add_page_to_extra_context(DeleteView.as_view())

--- a/feincms/views/generic/date_based.py
+++ b/feincms/views/generic/date_based.py
@@ -1,11 +1,11 @@
-from django.views.generic import date_based
+from django.views.generic import dates
 from feincms.views.decorators import add_page_to_extra_context
 
 
-archive_index = add_page_to_extra_context(date_based.archive_index)
-archive_year = add_page_to_extra_context(date_based.archive_year)
-archive_month = add_page_to_extra_context(date_based.archive_month)
-archive_week = add_page_to_extra_context(date_based.archive_week)
-archive_day = add_page_to_extra_context(date_based.archive_day)
-archive_today = add_page_to_extra_context(date_based.archive_today)
-object_detail = add_page_to_extra_context(date_based.object_detail)
+archive_index = add_page_to_extra_context(dates.ArchiveIndexView.as_view())
+archive_year = add_page_to_extra_context(dates.YearArchiveView.as_view())
+archive_month = add_page_to_extra_context(dates.MonthArchiveView.as_view())
+archive_week = add_page_to_extra_context(dates.WeekArchiveView.as_view())
+archive_day = add_page_to_extra_context(dates.DayArchiveView.as_view())
+archive_today = add_page_to_extra_context(dates.TodayArchiveView.as_view())
+object_detail = add_page_to_extra_context(dates.DateDetailView.as_view())

--- a/feincms/views/generic/list_detail.py
+++ b/feincms/views/generic/list_detail.py
@@ -1,6 +1,6 @@
-from django.views.generic import list_detail
+from django.views.generic import DetailView, ListView
 from feincms.views.decorators import add_page_to_extra_context
 
 
-object_list = add_page_to_extra_context(list_detail.object_list)
-object_detail = add_page_to_extra_context(list_detail.object_detail)
+object_list = add_page_to_extra_context(ListView.as_view())
+object_detail = add_page_to_extra_context(DetailView.as_view())

--- a/feincms/views/generic/simple.py
+++ b/feincms/views/generic/simple.py
@@ -1,5 +1,5 @@
-from django.views.generic import simple
+from django.views.generic import TemplateView
 from feincms.views.decorators import add_page_to_extra_context
 
 
-direct_to_template = add_page_to_extra_context(simple.direct_to_template)
+direct_to_template = add_page_to_extra_context(TemplateView.as_view())


### PR DESCRIPTION
... to support Django 1.4 _and_ 1.5.

Included blog example app works and a site I'm currently upgrading FeinCMS on works with this change (though it doesn't utilise all of the views admittedly).

Towards #430.
