### PR TITLE
Added support for setting custom django permissions in content type models

### DIFF
--- a/feincms/models.py
+++ b/feincms/models.py
@@ -647,6 +647,7 @@ def create_base_model(inherit_from=models.Model):
                 db_table = '%s_%s' % (cls._meta.db_table, class_name.lower())
                 verbose_name = model._meta.verbose_name
                 verbose_name_plural = model._meta.verbose_name_plural
+                permissions = model._meta.permissions
 
             attrs = {
                 # put the concrete content type into the


### PR DESCRIPTION
Currently FeinCMS ignores custom permissions which are set in content type models.
So, for example, this code will not work as expected (defined permissions are ignored):

```
class SomeCustomContent(models.Model):
    ...
    class Meta:
        abstract = True
        permissions = (
            ("view_task", "Can see available tasks"),
            ("change_task_status", "Can change the status of tasks"),
            ("close_task", "Can remove a task"),
        )
```

This change adds support for custom permissions in content type models.
