### PR TITLE
css hacks for django-suit compatibility

### DIFF
--- a/feincms/static/feincms/style.css
+++ b/feincms/static/feincms/style.css
@@ -325,3 +325,40 @@ div.order-machine div.inline-related > h3{
 
 /* various overrides */
 #id_redirect_to { width: 20em; } /* raw_id_fields act-a-like for redirect_to */
+
+
+/* django suit hacks */
+/*********************/
+
+#suit-center #main {
+    clear:none;
+}
+
+#suit-center .panel {
+    padding-top: 15px;
+}
+
+#suit-center .form-horizontal .inline-related fieldset {
+    margin-top: 10px;
+}
+
+#suit-center .panel h2 {
+    color: white;
+    font-size: 13px;
+    line-height: 12px;
+    margin-left: 0;
+    text-shadow: none;
+}
+
+#suit-center .item-delete {
+    margin: 3px 5px 0 0;
+}
+
+#suit-center .order-item .handle {
+    height: 36px;
+}
+
+#suit-center .order-machine .order-item {
+    margin-top: 10px;
+}
+


### PR DESCRIPTION
These are some simple css hacks, to make the feincms item editor looks nice in django-suit. Because its only some lines of css, I think this can be merged into master.
