### PR TITLE
FeinCMSModelAdmin breaks when using a custom model manager

### DIFF
--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -55,7 +55,7 @@ def _build_tree_structure(cls):
 
     mptt_opts = cls._mptt_meta
 
-    for p_id, parent_id in cls.objects.order_by(mptt_opts.tree_id_attr, mptt_opts.left_attr).values_list("pk", "%s_id" % mptt_opts.parent_attr):
+    for p_id, parent_id in cls._default_manager.order_by(mptt_opts.tree_id_attr, mptt_opts.left_attr).values_list("pk", "%s_id" % mptt_opts.parent_attr):
         all_nodes[p_id] = []
 
         if parent_id:


### PR DESCRIPTION
`FeinCMSModelAdmin` does not use first manager in model like Django's admin does, which might conflict with the `objects` manager.

I'm using just the `FeinCMSModelAdmin` of FeinCMS for a MPTT model. It breaks because the manager defined as `objects` filters some items, but the first manager (which the admin uses) shows all objects. FeinCMSModelAdmin should use the first manager to not have some conflict.
