### PR TITLE
Optimize translations extension by prefetching translations.

### DIFF
--- a/feincms/module/extensions/translations.py
+++ b/feincms/module/extensions/translations.py
@@ -16,6 +16,7 @@ non-FeinCMS managed views such as Django's administration tool.
 
 # ------------------------------------------------------------------------
 import logging
+from functools import wraps
 
 from django.conf import settings as django_settings
 from django.db import models
@@ -190,18 +191,19 @@ class Extension(extensions.Extension):
 
     def handle_modeladmin(self, modeladmin):
 
-        old_queryset = modeladmin.queryset
+        """
+        Extend default queryset to prefetch translations.
+        """
+        def wrap_queryset(f):
+            @wraps(f)
+            def wrapper(request, *args, **kwargs):
+                qs = f(request, *args, **kwargs)
+                qs = qs.prefetch_related('translation_of__translations',
+                                         'translations')
+                return qs
+            return wrapper
 
-        def queryset(request):
-            """
-            Extend default queryset to prefetch translations.
-            """
-            qs = old_queryset(request)
-            qs = qs.prefetch_related('translation_of__translations',
-                                     'translations')
-            return qs
-
-        modeladmin.queryset = queryset
+        modeladmin.queryset = wrap_queryset(modeladmin.queryset)
 
         def available_translations_admin(self, page):
             translations = dict((p.language, p.id) for p in page.available_translations())


### PR DESCRIPTION
This is work in progress (please do not pull)

Based on my tests with 364 pages, 2 languages:

Original: 445 queries in 520.63ms
Patched: 11 queries in 72.40ms

I am not too happy with patching `old_queryset` in modeladmin, any idea is welcomed.
