### PR TITLE
use djangos default permission_denied view instead of the raw HTTPRespon...

### DIFF
--- a/docs/page.rst
+++ b/docs/page.rst
@@ -262,13 +262,15 @@ request as parameters and returns either None (or nothing) or a HttpResponse.
 All registered request processors are run before the page is actually rendered.
 If the request processor indeed returns a :class:`HttpResponse`, further rendering of
 the page is cut short and this response is returned immediately to the client.
+It is also possible to raise an exception which will be handled like all exceptions
+are handled in Django views.
 
 This allows for various actions dependent on page and request, for example a
 simple user access check can be implemented like this::
 
     def authenticated_request_processor(page, request):
         if not request.user.is_authenticated():
-            return django.views.defaults.permission_denied()
+            raise django.core.exceptions.PermissionDenied
 
     Page.register_request_processor(authenticated_request_processor)
 


### PR DESCRIPTION
Hi,

updated the docs to use the default permission_denied view instead of the raw HttpResponseForbidden. This makes the example more obvious, as the permission_denied view will either use the 403.html template or return the string 403 Forbidden and also uses HttpResponseForbidden.

Regards
    Adi
