### PR TITLE
In the docs, mention that FEINCMS_RICHTEXT_INIT_TEMPLATE needs to be set...

### DIFF
--- a/feincms/content/richtext/models.py
+++ b/feincms/content/richtext/models.py
@@ -64,6 +64,9 @@ class RichTextContent(models.Model):
     anything you want using ``FEINCMS_RICHTEXT_INIT_CONTEXT`` and
     ``FEINCMS_RICHTEXT_INIT_TEMPLATE``.
 
+    If you are using TinyMCE 4.x then ``FEINCMS_RICHTEXT_INIT_TEMPLATE`` 
+    needs to be set to ``admin/content/richtext/init_tinymce4.html``.
+
     Optionally runs the HTML code through HTML cleaners if you specify
     ``cleanse=True`` when calling ``create_content_type``.
     """


### PR DESCRIPTION
... if using TinyMCE 4.x

When using TinyMCE 4.x the user has to set FEINCMS_RICHTEXT_INIT_TEMPLATE to the init_tinymce4.html template for the rich text content to work correctly.

This pull request should also be merged into the next branch.

Cheers
   Adi
