### PR TITLE
Fixed broken content type headings when class name contains an underscor...

### DIFF
--- a/feincms/static/feincms/item_editor.js
+++ b/feincms/static/feincms/item_editor.js
@@ -503,7 +503,7 @@ if(!Array.indexOf) {
                     elem.find(".region-choice-field").val());
                 if (REGION_MAP[region_id] != undefined) {
                     var content_type = elem.attr("id").substr(
-                        0, elem.attr("id").indexOf("_"));
+                        0, elem.attr("id").lastIndexOf("_"));
                     var item = create_new_item_from_form(
                         elem, CONTENT_NAMES[content_type], content_type);
                     add_fieldset(region_id, item, {where:'append'});


### PR DESCRIPTION
...e.

  (No, I don't use underscores in class names, except when doing crazy
   namespacing stuff for multiple FeinCMS base classes sharing the same
   content types...)
