### PR TITLE
Shared content proxy

### DIFF
--- a/feincms/models.py
+++ b/feincms/models.py
@@ -224,6 +224,13 @@ class ContentProxy(object):
                 else:
                     self._cache['cts'][cls] = []
 
+        # share this content proxy object between all content items
+        # so that each can use obj.parent.content to determine its
+        # relationship to its siblings, etc.
+        for cls, objects in self._cache['cts'].items():
+            for obj in objects:
+                setattr(obj.parent, '_content_proxy', self)
+
     def _fetch_regions(self):
         """
         Fetches all content types and group content types into regions


### PR DESCRIPTION
Not sure whether this could have negative side effects for other use cases, but it allows me to reference `self.parent.content` in a `Content` base class, with zero additional queries, to implement methods like `is_first_in_region`, `is_first_of_type`, `last_in_group`, `earlier_siblings`, etc. Could easily implement as a custom `ContentProxy` base class but wondered if this functionality, or a variant thereof, may be widely useful.
