### PR TITLE
travis: always test with the latest patch release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,18 @@ python:
   - "3.2"
   - "3.3"
 env:
-  - DJANGO_VERSION=1.4.10
-  - DJANGO_VERSION=1.5.5
-  - DJANGO_VERSION=1.6.0
+  - DJANGO_REQUIREMENT="Django>=1.4,<1.5"
+  - DJANGO_REQUIREMENT="Django>=1.5,<1.6"
+  - DJANGO_REQUIREMENT="Django>=1.6,<1.7"
 matrix:
   exclude:
     - python: "3.2"
-      env: DJANGO_VERSION=1.4.10
+      env: DJANGO_REQUIREMENT="Django>=1.4,<1.5"
     - python: "3.3"
-      env: DJANGO_VERSION=1.4.10
+      env: DJANGO_REQUIREMENT="Django>=1.4,<1.5"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -q Django==$DJANGO_VERSION django-mptt Pillow feedparser flake8 --use-mirrors
+  - pip install -q $DJANGO_REQUIREMENT django-mptt Pillow feedparser flake8 --use-mirrors
   - python setup.py -q install
 # command to run tests, e.g. python setup.py test
 script: "cd tests && ./manage.py test testapp && flake8 ."


### PR DESCRIPTION
Now it's not needed anymore to specify an exact patch release. This is an improvement because we will discover breaking stuff in django patch releases earlier. This also opens the possibility to add https://github.com/django/django/zipball/master as a new build.
