### PR TITLE
added support for changing quality in thumbnails

### DIFF
--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -187,6 +187,14 @@ FEINCMS_THUMBNAIL_DIR = getattr(
     '_thumbs/')
 
 # ------------------------------------------------------------------------
+#: Default quality settings when creating thumbnails as a percentage of
+#: the original quality. 60 would equal a 40 decrease in quality.
+FEINCMS_THUMBNAIL_QUALITY = getattr(
+    settings,
+    'FEINCMS_THUMBNAIL_QUALITY',
+    90)
+
+# ------------------------------------------------------------------------
 #: Prevent changing template within admin for pages which have been
 #: allocated a Template with singleton=True -- template field will become
 #: read-only for singleton pages.


### PR DESCRIPTION
The fincms_thumbnail tags are used for much more than generating small
thumbs. I have added the option of setting the quality to save
bandwidth on image heavy pages. It can be set in the settings file or
on a per-use basis which will override the value in settings. This will
cause all images to regenerate as quality is now part of the filename.