### PR TITLE
Typo in templatetags avoid using show_content_type_selection_widget

### DIFF
--- a/feincms/templatetags/feincms_tags.py
+++ b/feincms/templatetags/feincms_tags.py
@@ -86,7 +86,7 @@ def show_content_type_selection_widget(context, region):
     """
     if 'request' in context:
         user = context['request'].user
-    elif user in context:
+    elif 'user' in context:
         user = context['user']
     else:
         user = None


### PR DESCRIPTION
In https://github.com/feincms/feincms/blob/3013dcb5219b8e847583c92e06465e02a1e05d3f/feincms/templatetags/feincms_tags.py#L89

`user` should contain quote as otherwise we get an error.

Stacktrace:

``` bash
Template error:
In template /Users/k/.envs/website/lib/python3.4/site-packages/feincms/templates/admin/feincms/content_editor.html, error at line 34
   local variable 'user' referenced before assignment
   33 :                     <span>{% trans "Add new item" %}:</span> <br/>
   34 :                      {% show_content_type_selection_widget region %} 
   35 :                     <input type="button" class="order-machine-add-button button" value="Go" />

Traceback:
File "/Users/k/.envs/ukcpa-website/lib/python3.4/site-packages/feincms/templatetags/feincms_tags.py" in show_content_type_selection_widget
  89.     elif user in context:

Exception Type: UnboundLocalError at /admin/news/article/add/
Exception Value: local variable 'user' referenced before assignment
```
