### PR TITLE
Django 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 env:
   - DJANGO_REQUIREMENT="Django>=1.6,<1.7"
   - DJANGO_REQUIREMENT="Django>=1.7,<1.8"
+  - DJANGO_REQUIREMENT="Django>=1.8,<1.9"
 matrix:
   exclude:
     - python: "2.6"

--- a/feincms/__init__.py
+++ b/feincms/__init__.py
@@ -62,34 +62,37 @@ def ensure_completely_loaded(force=False):
     # Here we flush the caches rather than actually _filling them so
     # that relations defined after all content types registrations
     # don't miss out.
-    from feincms._internal import get_models
-    for model in get_models():
-        for cache_name in (
-                '_field_cache', '_field_name_cache', '_m2m_cache',
-                '_related_objects_cache', '_related_many_to_many_cache',
-                '_name_map'):
+    import django
+    if django.get_version() < '1.8':
+
+        from feincms._internal import get_models
+        for model in get_models():
+            for cache_name in (
+                    '_field_cache', '_field_name_cache', '_m2m_cache',
+                    '_related_objects_cache', '_related_many_to_many_cache',
+                    '_name_map'):
+                try:
+                    delattr(model._meta, cache_name)
+                except AttributeError:
+                    pass
+
+            # Randomly call some cache filling methods
+            # http://goo.gl/XNI2qz
+            model._meta._fill_fields_cache()
+
+        # Calls to get_models(...) are cached by the arguments used in the call.
+        # This cache is normally cleared in loading.register_models(), but we
+        # invalidate the get_models() cache, by calling get_models
+        # above before all apps have loaded. (Django's load_app() doesn't clear the
+        # get_models cache as it perhaps should). So instead we clear the
+        # get_models cache again here. If we don't do this, Django 1.5 chokes on
+        # a model validation error (Django 1.4 doesn't exhibit this problem).
+        # See Issue #323 on github.
+        if hasattr(apps, 'cache'):
             try:
-                delattr(model._meta, cache_name)
+                apps.cache.get_models.cache_clear()  # Django 1.7+
             except AttributeError:
-                pass
-
-        # Randomly call some cache filling methods
-        # http://goo.gl/XNI2qz
-        model._meta._fill_fields_cache()
-
-    # Calls to get_models(...) are cached by the arguments used in the call.
-    # This cache is normally cleared in loading.register_models(), but we
-    # invalidate the get_models() cache, by calling get_models
-    # above before all apps have loaded. (Django's load_app() doesn't clear the
-    # get_models cache as it perhaps should). So instead we clear the
-    # get_models cache again here. If we don't do this, Django 1.5 chokes on
-    # a model validation error (Django 1.4 doesn't exhibit this problem).
-    # See Issue #323 on github.
-    if hasattr(apps, 'cache'):
-        try:
-            apps.cache.get_models.cache_clear()  # Django 1.7+
-        except AttributeError:
-            apps.cache._get_models_cache.clear()  # Django 1.6-
+                apps.cache._get_models_cache.clear()  # Django 1.6-
 
     if hasattr(apps, 'ready'):
         if apps.ready:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'django-mptt>=0.6.0',
         'Pillow>=2.0.0',
         'feedparser>=5.0.0',
+        'pytz>=2014.10',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     },
     install_requires=[
         'Django>=1.6',
-        'django-mptt>=0.6.0',
+        'django-mptt>=0.7.1',
         'Pillow>=2.0.0',
         'feedparser>=5.0.0',
         'pytz>=2014.10',

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -33,6 +33,7 @@ BASEDIR = os.path.dirname(__file__)
 MEDIA_ROOT = os.path.join(BASEDIR, 'media/')
 STATIC_ROOT = os.path.join(BASEDIR, 'static/')
 SECRET_KEY = 'supersikret'
+USE_TZ = True
 
 ROOT_URLCONF = 'testapp.urls'
 LANGUAGES = (('en', 'English'), ('de', 'German'))

--- a/tests/testapp/tests/test_cms.py
+++ b/tests/testapp/tests/test_cms.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.test import TestCase
@@ -18,6 +19,15 @@ from feincms.content.video.models import VideoContent
 
 from testapp.models import ExampleCMSBase, ExampleCMSBase2
 from .test_stuff import Empty
+
+try:
+    from unittest import skipIf
+except:
+    from django.utils.unittest import skipIf
+
+skipUnlessLegacy = skipIf(
+    django.VERSION >= (1, 8),
+    "Legacy tests only necessary in Django < 1.8")
 
 
 # ------------------------------------------------------------------------
@@ -150,6 +160,7 @@ class CMSBaseTest(TestCase):
             ct2._meta.db_table,
             'testapp_examplecmsbase2_rawcontent2')
 
+    @skipUnlessLegacy
     def test_09_related_objects_cache(self):
         """
         We need to define a model with relationship to our Base *after* all

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -19,6 +19,7 @@ deps =
     Pillow==2.4.0
     lxml==3.2.3
     {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
-    {py27,py32,py33,py34}-django{17,18}: django-mptt==0.6.1
+    {py27,py32,py33,py34}-django17: django-mptt==0.6.1
+    {py27,py34}-django18: --editable=git+git://github.com/django-mptt/django-mptt.git#egg=django-mptt-dev
     {py26,py27}-django{16,17,18}: BeautifulSoup==3.2.1
     {py32,py33,py34}-django{16,17,18}: beautifulsoup4==4.3.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -21,6 +21,6 @@ deps =
     lxml==3.2.3
     {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
     {py27,py32,py33,py34}-django17: django-mptt==0.6.1
-    {py27,py34}-django18: --editable=git+git://github.com/django-mptt/django-mptt.git#egg=django-mptt-dev
+    {py27,py34}-django18: django-mptt==0.7.1
     {py26,py27}-django{16,17,18}: BeautifulSoup==3.2.1
     {py32,py33,py34}-django{16,17,18}: beautifulsoup4==4.3.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -2,108 +2,21 @@
 setupdir = ..
 distribute = False
 envlist =
-    py26-1.6.X,
-    py27-1.6.X,
-    py27-1.7.X,
-    py32-1.6.X,
-    py32-1.7.X,
-    py33-1.6.X,
-    py33-1.7.X,
-    py34-1.6.X,
-    py34-1.7.X,
+    {py26,py27,py32,py33,py34}-django16,
+    {py27,py32,py33,py34}-django17,
 
 [testenv]
 commands =
     {envpython} manage.py test {posargs:testapp} --settings=testapp.settings
 setenv =
     PYTHONPATH = .:{toxworkdir}/../..
-
-[testenv:py26-1.6.X]
-basepython = python2.6
 deps =
-    Django>=1.6,<1.7
-    django-mptt==0.6.0
-    Pillow==2.4.0
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
     feedparser==5.1.3
-    lxml==3.2.3
-    BeautifulSoup==3.2.1
-
-[testenv:py27-1.6.X]
-basepython = python2.7
-deps =
-    Django>=1.6,<1.7
-    django-mptt==0.6.0
     Pillow==2.4.0
-    feedparser==5.1.3
     lxml==3.2.3
-    BeautifulSoup==3.2.1
-
-[testenv:py27-1.7.X]
-basepython = python2.7
-deps =
-    Django>=1.7,<1.8
-    django-mptt==0.6.1
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    BeautifulSoup==3.2.1
-
-[testenv:py32-1.6.X]
-basepython = python3.2
-deps =
-    Django>=1.6,<1.7
-    django-mptt==0.6.0
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
-
-[testenv:py32-1.7.X]
-basepython = python3.2
-deps =
-    Django>=1.7,<1.8
-    django-mptt==0.6.1
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
-
-[testenv:py33-1.6.X]
-basepython = python3.3
-deps =
-    Django>=1.6,<1.7
-    django-mptt==0.6.0
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
-
-[testenv:py33-1.7.X]
-basepython = python3.3
-deps =
-    Django>=1.7,<1.8
-    django-mptt==0.6.1
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
-
-[testenv:py34-1.6.X]
-basepython = python3.4
-deps =
-    Django>=1.6,<1.7
-    django-mptt==0.6.0
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
-
-[testenv:py34-1.7.X]
-basepython = python3.4
-deps =
-    Django>=1.7,<1.8
-    django-mptt==0.6.1
-    Pillow==2.4.0
-    feedparser==5.1.3
-    lxml==3.2.3
-    beautifulsoup4==4.3.1
+    {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
+    {py27,py32,py33,py34}-django17: django-mptt==0.6.1
+    {py26,py27}-django{16,17}: BeautifulSoup==3.2.1
+    {py32,py33,py34}-django{16,17}: beautifulsoup4==4.3.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -17,7 +17,7 @@ deps =
     django18: Django>=1.8b1,<1.9
     feedparser==5.1.3
     Pillow==2.4.0
-    pytz>=2014.9
+    pytz==2014.10
     lxml==3.2.3
     {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
     {py27,py32,py33,py34}-django17: django-mptt==0.6.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -21,7 +21,7 @@ setenv =
 [testenv:py26-1.6.X]
 basepython = python2.6
 deps =
-    Django==1.6.0
+    Django>=1.6,<1.7
     django-mptt==0.6.0
     Pillow==2.4.0
     feedparser==5.1.3
@@ -31,7 +31,7 @@ deps =
 [testenv:py27-1.6.X]
 basepython = python2.7
 deps =
-    Django==1.6.0
+    Django>=1.6,<1.7
     django-mptt==0.6.0
     Pillow==2.4.0
     feedparser==5.1.3
@@ -41,7 +41,7 @@ deps =
 [testenv:py27-1.7.X]
 basepython = python2.7
 deps =
-    Django==1.7
+    Django>=1.7,<1.8
     django-mptt==0.6.1
     Pillow==2.4.0
     feedparser==5.1.3
@@ -51,7 +51,7 @@ deps =
 [testenv:py32-1.6.X]
 basepython = python3.2
 deps =
-    Django==1.6.0
+    Django>=1.6,<1.7
     django-mptt==0.6.0
     Pillow==2.4.0
     feedparser==5.1.3
@@ -61,7 +61,7 @@ deps =
 [testenv:py32-1.7.X]
 basepython = python3.2
 deps =
-    Django==1.7
+    Django>=1.7,<1.8
     django-mptt==0.6.1
     Pillow==2.4.0
     feedparser==5.1.3
@@ -71,7 +71,7 @@ deps =
 [testenv:py33-1.6.X]
 basepython = python3.3
 deps =
-    Django==1.6.0
+    Django>=1.6,<1.7
     django-mptt==0.6.0
     Pillow==2.4.0
     feedparser==5.1.3
@@ -81,7 +81,7 @@ deps =
 [testenv:py33-1.7.X]
 basepython = python3.3
 deps =
-    Django==1.7
+    Django>=1.7,<1.8
     django-mptt==0.6.1
     Pillow==2.4.0
     feedparser==5.1.3
@@ -91,7 +91,7 @@ deps =
 [testenv:py34-1.6.X]
 basepython = python3.4
 deps =
-    Django==1.6.0
+    Django>=1.6,<1.7
     django-mptt==0.6.0
     Pillow==2.4.0
     feedparser==5.1.3
@@ -101,7 +101,7 @@ deps =
 [testenv:py34-1.7.X]
 basepython = python3.4
 deps =
-    Django==1.7
+    Django>=1.7,<1.8
     django-mptt==0.6.1
     Pillow==2.4.0
     feedparser==5.1.3

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -14,7 +14,7 @@ setenv =
 deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
-    django18: Django>=1.8b1,<1.9
+    django18: Django>=1.8,<1.9
     feedparser==5.1.3
     Pillow==2.4.0
     pytz==2014.10

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -17,6 +17,7 @@ deps =
     django18: Django>=1.8b1,<1.9
     feedparser==5.1.3
     Pillow==2.4.0
+    pytz>=2014.9
     lxml==3.2.3
     {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
     {py27,py32,py33,py34}-django17: django-mptt==0.6.1

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -4,6 +4,7 @@ distribute = False
 envlist =
     {py26,py27,py32,py33,py34}-django16,
     {py27,py32,py33,py34}-django17,
+    {py27,py34}-django18,
 
 [testenv]
 commands =
@@ -13,10 +14,11 @@ setenv =
 deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
+    django18: Django>=1.8b1,<1.9
     feedparser==5.1.3
     Pillow==2.4.0
     lxml==3.2.3
     {py26,py27,py32,py33,py34}-django16: django-mptt==0.6.0
-    {py27,py32,py33,py34}-django17: django-mptt==0.6.1
-    {py26,py27}-django{16,17}: BeautifulSoup==3.2.1
-    {py32,py33,py34}-django{16,17}: beautifulsoup4==4.3.1
+    {py27,py32,py33,py34}-django{17,18}: django-mptt==0.6.1
+    {py26,py27}-django{16,17,18}: BeautifulSoup==3.2.1
+    {py32,py33,py34}-django{16,17,18}: beautifulsoup4==4.3.1


### PR DESCRIPTION
Django 1.8 beta 1 was released recently.
https://www.djangoproject.com/weblog/2015/feb/25/releases/

This branch makes a start on supporting Django 1.8 on top of the `next` branch, though I don't know how to get past the last failing test (edit: when running `tox`):

ERROR: test_29_medialibrary_admin (testapp.tests.test_page.PagesTestCase)
...
AttributeError: 'ManyToManyRel' object has no attribute 'parent_model'
