### PR TITLE
make FeinCMS compatible with django-reversion >= 1.10

### DIFF
--- a/feincms/models.py
+++ b/feincms/models.py
@@ -822,7 +822,10 @@ def create_base_model(inherit_from=models.Model):
             try:
                 from reversion import revisions as reversion
             except ImportError:
-                raise EnvironmentError("django-reversion is not installed")
+                try:
+                    import reversion
+                except ImportError:
+                    raise EnvironmentError("django-reversion is not installed")
 
             follow = []
             for content_type in cls._feincms_content_types:

--- a/feincms/models.py
+++ b/feincms/models.py
@@ -820,7 +820,7 @@ def create_base_model(inherit_from=models.Model):
         @classmethod
         def register_with_reversion(cls):
             try:
-                import reversion
+                from reversion import revisions as reversion
             except ImportError:
                 raise EnvironmentError("django-reversion is not installed")
 


### PR DESCRIPTION
see http://django-reversion.readthedocs.org/en/latest/api.html
see https://github.com/etianen/django-reversion/commit/755de5cc471b83b92aa731c0e58b452d205ed414

tested with Django (1.8.7), FeinCMS (1.11.1)