### PR TITLE
Correct compatibility for django-reversion >= 1.10

### DIFF
--- a/feincms/models.py
+++ b/feincms/models.py
@@ -831,18 +831,18 @@ def create_base_model(inherit_from=models.Model):
         @classmethod
         def register_with_reversion(cls):
             try:
-                from reversion import revisions as reversion
+                from reversion.revisions import register
             except ImportError:
                 try:
-                    import reversion
+                    from reversion import register
                 except ImportError:
                     raise EnvironmentError("django-reversion is not installed")
 
             follow = []
             for content_type in cls._feincms_content_types:
                 follow.append('%s_set' % content_type.__name__.lower())
-                reversion.register(content_type)
-            reversion.register(cls, follow=follow)
+                register(content_type)
+            register(cls, follow=follow)
 
     return Base
 


### PR DESCRIPTION
django-reversion's revisions.py module dates back to version 1.0 and so the initial import (from reversion import revisions as reversion) will always succeed. The revisions.register attribute was added in version 1.10.

I've tested this with FeinCMS 1.11.4 and django-reversion 1.8.6.