### PR TITLE
Freeze django mptt version because mptt drops support for django 1.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     },
     install_requires=[
         'Django>=1.6',
-        'django-mptt>=0.7.1',
+        'django-mptt>=0.7.1,<0.8.0',
         'Pillow>=2.0.0',
         'feedparser>=5.0.0',
         'pytz>=2014.10',


### PR DESCRIPTION
https://github.com/django-mptt/django-mptt/releases

I don't know if this restrictions is good, but 0.8 not works on < 1.8

I have solved this droping 1.7 too in Leonardo CMS.