### PR TITLE
Language detection/switching fix

### DIFF
--- a/feincms/contrib/preview/urls.py
+++ b/feincms/contrib/preview/urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from feincms.contrib.preview.views import PreviewHandler
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^(.*)/_preview/(\d+)/$', PreviewHandler.as_view(),
-        name='feincms_preview'),
-)
+        name='feincms_preview')
+]

--- a/feincms/module/extensions/translations.py
+++ b/feincms/module/extensions/translations.py
@@ -35,6 +35,7 @@ from feincms._internal import monkeypatch_method, monkeypatch_property
 logger = logging.getLogger(__name__)
 
 LANGUAGE_COOKIE_NAME = django_settings.LANGUAGE_COOKIE_NAME
+LANGUAGE_SESSION_KEY = translation.LANGUAGE_SESSION_KEY
 
 
 # ------------------------------------------------------------------------
@@ -45,7 +46,7 @@ def user_has_language_set(request):
     site's language settings, after all, the user's decision is what counts.
     """
     if (hasattr(request, 'session')
-            and request.session.get(LANGUAGE_COOKIE_NAME) is not None):
+            and request.session.get(LANGUAGE_SESSION_KEY) is not None):
         return True
     if LANGUAGE_COOKIE_NAME in request.COOKIES:
         return True
@@ -87,8 +88,8 @@ def translation_set_language(request, select_language):
 
     if hasattr(request, 'session'):
         # User has a session, then set this language there
-        if select_language != request.session.get(LANGUAGE_COOKIE_NAME):
-            request.session[LANGUAGE_COOKIE_NAME] = select_language
+        if select_language != request.session.get(LANGUAGE_SESSION_KEY):
+            request.session[LANGUAGE_SESSION_KEY] = select_language
     elif request.method == 'GET' and not fallback:
         # No session is active. We need to set a cookie for the language
         # so that it persists when users change their location to somewhere

--- a/feincms/module/extensions/translations.py
+++ b/feincms/module/extensions/translations.py
@@ -35,7 +35,7 @@ from feincms._internal import monkeypatch_method, monkeypatch_property
 logger = logging.getLogger(__name__)
 
 LANGUAGE_COOKIE_NAME = django_settings.LANGUAGE_COOKIE_NAME
-if translation.LANGUAGE_SESSION_KEY:
+if hasattr(translation, 'LANGUAGE_SESSION_KEY'):
     LANGUAGE_SESSION_KEY = translation.LANGUAGE_SESSION_KEY
 else:
     # Django 1.6

--- a/feincms/module/extensions/translations.py
+++ b/feincms/module/extensions/translations.py
@@ -35,7 +35,11 @@ from feincms._internal import monkeypatch_method, monkeypatch_property
 logger = logging.getLogger(__name__)
 
 LANGUAGE_COOKIE_NAME = django_settings.LANGUAGE_COOKIE_NAME
-LANGUAGE_SESSION_KEY = translation.LANGUAGE_SESSION_KEY
+if translation.LANGUAGE_SESSION_KEY:
+    LANGUAGE_SESSION_KEY = translation.LANGUAGE_SESSION_KEY
+else:
+    # Django 1.6
+    LANGUAGE_SESSION_KEY = LANGUAGE_COOKIE_NAME
 
 
 # ------------------------------------------------------------------------

--- a/feincms/module/medialibrary/modeladmins.py
+++ b/feincms/module/medialibrary/modeladmins.py
@@ -124,18 +124,17 @@ class MediaFileAdmin(ExtensionModelAdmin):
     actions = [assign_category, save_as_zipfile]
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
 
         urls = super(MediaFileAdmin, self).get_urls()
-        my_urls = patterns(
-            '',
+        my_urls = [
             url(
                 r'^mediafile-bulk-upload/$',
                 self.admin_site.admin_view(MediaFileAdmin.bulk_upload),
                 {},
                 name='mediafile_bulk_upload',
-            ),
-        )
+            )
+        ]
 
         return my_urls + urls
 

--- a/feincms/urls.py
+++ b/feincms/urls.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from feincms.views.cbv.views import Handler
 

--- a/feincms/urls.py
+++ b/feincms/urls.py
@@ -7,8 +7,7 @@ from feincms.views.cbv.views import Handler
 
 handler = Handler.as_view()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', handler, name='feincms_home'),
-    url(r'^(.*)/$', handler, name='feincms_handler'),
-)
+    url(r'^(.*)/$', handler, name='feincms_handler')
+]

--- a/tests/testapp/applicationcontent_urls.py
+++ b/tests/testapp/applicationcontent_urls.py
@@ -4,7 +4,7 @@ This is a dummy module used to test the ApplicationContent
 
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -54,8 +54,7 @@ def inheritance20_unpack(request):
     return response
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', module_root, name='ac_module_root'),
     url(r'^args_test/([^/]+)/([^/]+)/$', args_test, name='ac_args_test'),
     url(r'^kwargs_test/(?P<kwarg2>[^/]+)/(?P<kwarg1>[^/]+)/$', args_test),
@@ -66,5 +65,5 @@ urlpatterns = patterns(
     url(r'^response/$', response),
     url(r'^response_decorated/$', standalone(response)),
     url(r'^inheritance20/$', inheritance20),
-    url(r'^inheritance20_unpack/$', inheritance20_unpack),
-)
+    url(r'^inheritance20_unpack/$', inheritance20_unpack)
+]

--- a/tests/testapp/blog_urls.py
+++ b/tests/testapp/blog_urls.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views import generic
 
 from feincms.module.blog.models import Entry
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         r'^(?P<pk>\d+)/',
         generic.DetailView.as_view(
@@ -19,5 +18,5 @@ urlpatterns = patterns(
             queryset=Entry.objects.all(),
         ),
         name='blog_entry_list'
-    ),
-)
+    )
+]

--- a/tests/testapp/tests/test_extensions.py
+++ b/tests/testapp/tests/test_extensions.py
@@ -4,9 +4,11 @@ from __future__ import absolute_import, unicode_literals
 
 from django.contrib.sites.models import Site
 from django.template.defaultfilters import slugify
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.utils.translation import LANGUAGE_SESSION_KEY
 
 from feincms.module.page.models import Page
+from feincms.module.extensions.translations import user_has_language_set, translation_set_language
 
 
 class TranslationTestCase(TestCase):
@@ -61,3 +63,23 @@ class TranslationTestCase(TestCase):
 
         # TODO:  add request tests
         # with translation.override('de'):
+
+    def test_user_has_language_set(self):
+        factory = RequestFactory()
+        request = factory.get(self.page_en.get_navigation_url())
+        setattr(request, 'session', dict())
+        request.session[LANGUAGE_SESSION_KEY] = 'en'
+        self.assertEqual(user_has_language_set(request), True)
+
+        setattr(request, 'session', dict())
+        request.COOKIES['django_language'] = 'en'
+        self.assertEqual(user_has_language_set(request), True)
+
+    def test_translation_set_language(self):
+        factory = RequestFactory()
+        request = factory.get(self.page_en.get_navigation_url())
+        setattr(request, 'session', dict())
+        translation_set_language(request, 'en')
+
+        self.assertEqual(request.LANGUAGE_CODE, 'en')
+        self.assertEqual(request.session[LANGUAGE_SESSION_KEY], 'en')

--- a/tests/testapp/tests/test_extensions.py
+++ b/tests/testapp/tests/test_extensions.py
@@ -5,11 +5,12 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib.sites.models import Site
 from django.template.defaultfilters import slugify
 from django.test import TestCase, RequestFactory
-from django.utils.translation import LANGUAGE_SESSION_KEY
+from django.utils import translation
 from django.conf import settings as django_settings
 
 from feincms.module.page.models import Page
-from feincms.module.extensions.translations import user_has_language_set, translation_set_language
+from feincms.module.extensions.translations import user_has_language_set,\
+    translation_set_language
 
 
 class TranslationTestCase(TestCase):
@@ -34,6 +35,12 @@ class TranslationTestCase(TestCase):
         de.parent.save()
         self.page_de = de.parent
         self.page_en = en.parent
+
+        if translation.LANGUAGE_SESSION_KEY:
+            self.language_session_key = translation.LANGUAGE_SESSION_KEY
+        else:
+            # Django 1.6
+            self.language_session_key = django_settings.LANGUAGE_COOKIE_NAME
 
     def create_page(self, title='Test page', parent=None, **kwargs):
         defaults = {
@@ -69,7 +76,7 @@ class TranslationTestCase(TestCase):
         factory = RequestFactory()
         request = factory.get(self.page_en.get_navigation_url())
         setattr(request, 'session', dict())
-        request.session[LANGUAGE_SESSION_KEY] = 'en'
+        request.session[self.language_session_key] = 'en'
         self.assertEqual(user_has_language_set(request), True)
 
     def test_user_has_language_set_with_cookie(self):
@@ -86,7 +93,7 @@ class TranslationTestCase(TestCase):
         translation_set_language(request, 'en')
 
         self.assertEqual(request.LANGUAGE_CODE, 'en')
-        self.assertEqual(request.session[LANGUAGE_SESSION_KEY], 'en')
+        self.assertEqual(request.session[self.language_session_key], 'en')
 
     def test_translation_set_language_to_cookie(self):
         factory = RequestFactory()

--- a/tests/testapp/tests/test_extensions.py
+++ b/tests/testapp/tests/test_extensions.py
@@ -9,8 +9,8 @@ from django.utils import translation
 from django.conf import settings as django_settings
 
 from feincms.module.page.models import Page
-from feincms.module.extensions.translations import user_has_language_set,\
-    translation_set_language
+from feincms.module.extensions.translations import user_has_language_set
+from feincms.module.extensions.translations import translation_set_language
 
 
 class TranslationTestCase(TestCase):
@@ -101,4 +101,6 @@ class TranslationTestCase(TestCase):
         response = translation_set_language(request, 'en')
 
         self.assertEqual(request.LANGUAGE_CODE, 'en')
-        self.assertEqual(response.cookies[django_settings.LANGUAGE_COOKIE_NAME].value, 'en')
+
+        c_key = django_settings.LANGUAGE_COOKIE_NAME
+        self.assertEqual(response.cookies[c_key].value, 'en')

--- a/tests/testapp/tests/test_extensions.py
+++ b/tests/testapp/tests/test_extensions.py
@@ -36,7 +36,7 @@ class TranslationTestCase(TestCase):
         self.page_de = de.parent
         self.page_en = en.parent
 
-        if translation.LANGUAGE_SESSION_KEY:
+        if hasattr(translation, 'LANGUAGE_SESSION_KEY'):
             self.language_session_key = translation.LANGUAGE_SESSION_KEY
         else:
             # Django 1.6

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
@@ -13,8 +13,7 @@ sitemaps = {'pages': PageSitemap}
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
     url(
@@ -30,7 +29,7 @@ urlpatterns = patterns(
     ),
 
     url(r'', include('feincms.contrib.preview.urls')),
-    url(r'', include('feincms.views.cbv.urls')),
-)
+    url(r'', include('feincms.views.cbv.urls'))
+]
 
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Hi,
I have run into into a bug where the redirect_to feature in page module  redirected the request to wrong language mutation of the particular page and the admin did not reflect to the change of FE language.

It was a side effect of unfunctional session lang code storage. The former implementation presumed that the LANGUAGE_SESSION_KEY and LANGUAGE_COOKIE_NAME have the same value. Which is not true anymore, at least for newer django versions (1.8.7, 1.9.5). 

Currently LANGUAGE_SESSION_KEY = '_language' and  LANGUAGE_COOKIE_NAME = 'django_language').

The pull request contains the lang issue fix with some simple tests together with some deprecation warnings corrections.

Thanks.

Martin

