### PR TITLE
URL 'patterns' is deprecated

### DIFF
--- a/feincms/module/medialibrary/modeladmins.py
+++ b/feincms/module/medialibrary/modeladmins.py
@@ -124,11 +124,10 @@ class MediaFileAdmin(ExtensionModelAdmin):
     actions = [assign_category, save_as_zipfile]
 
     def get_urls(self):
-        from django.conf.urls import patterns, url
+        from django.conf.urls import url
 
         urls = super(MediaFileAdmin, self).get_urls()
-        my_urls = patterns(
-            '',
+        my_urls = (
             url(
                 r'^mediafile-bulk-upload/$',
                 self.admin_site.admin_view(MediaFileAdmin.bulk_upload),

--- a/feincms/module/medialibrary/modeladmins.py
+++ b/feincms/module/medialibrary/modeladmins.py
@@ -127,14 +127,14 @@ class MediaFileAdmin(ExtensionModelAdmin):
         from django.conf.urls import url
 
         urls = super(MediaFileAdmin, self).get_urls()
-        my_urls = (
+        my_urls = [
             url(
                 r'^mediafile-bulk-upload/$',
                 self.admin_site.admin_view(MediaFileAdmin.bulk_upload),
                 {},
                 name='mediafile_bulk_upload',
             ),
-        )
+        ]
 
         return my_urls + urls
 


### PR DESCRIPTION
This addresses the `RemovedInDjango110Warning` being thrown by Django for this.

```
W: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead. [modeladmins.py:136]
```