### PR TITLE
Added a setting to allow arbitrary path prefix when using `add_page_if_missing`.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -72,6 +72,11 @@ by :mod:`feincms.module.page`.
 random gunk after a valid page URL. The standard behavior is to raise a 404
 if extra path elements aren't handled by a content type's ``process()`` method.
 
+``FEINCMS_ALLOW_EXTRA_PATH_PREFIX``: Defaults to ``()``. Define a tuple of 
+strings to allow predetermined url prefixes to be ignored. The standard behavior 
+is to raise a 404 if extra path elements aren't handled by a content type's 
+``process()`` method.
+
 ``FEINCMS_TRANSLATION_POLICY``: Defaults to ``STANDARD``.  How to switch
 languages.
 

--- a/feincms/content/application/models.py
+++ b/feincms/content/application/models.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from collections import OrderedDict
 from email.utils import parsedate
 from functools import partial, wraps
 from time import mktime
@@ -171,7 +172,7 @@ class ApplicationContent(models.Model):
     # MyBlogApp for blog <slug>")
     parameters = JSONField(null=True, editable=False)
 
-    ALL_APPS_CONFIG = {}
+    ALL_APPS_CONFIG = OrderedDict()
 
     class Meta:
         abstract = True

--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -91,6 +91,15 @@ FEINCMS_ALLOW_EXTRA_PATH = getattr(
     False)
 
 # ------------------------------------------------------------------------
+#: Allow random prefixes to be ignored when using 
+#: `Page.best_match_for_path()` and the `add_page_if_missing` context
+#: processor.
+FEINCMS_ALLOW_EXTRA_PATH_PREFIX = getattr(
+    settings,
+    'FEINCMS_ALLOW_EXTRA_PATH_PREFIX',
+    ())
+
+# ------------------------------------------------------------------------
 #: How to switch languages.
 #: * ``'STANDARD'``: The page a user navigates to sets the site's language
 #:   and overwrites whatever was set before.

--- a/feincms/default_settings.py
+++ b/feincms/default_settings.py
@@ -93,7 +93,8 @@ FEINCMS_ALLOW_EXTRA_PATH = getattr(
 # ------------------------------------------------------------------------
 #: Allow random prefixes to be ignored when using 
 #: `Page.best_match_for_path()` and the `add_page_if_missing` context
-#: processor.
+#: processor. 
+#: Defaults to an empty tuple.
 FEINCMS_ALLOW_EXTRA_PATH_PREFIX = getattr(
     settings,
     'FEINCMS_ALLOW_EXTRA_PATH_PREFIX',

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -76,7 +76,8 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
         path = path.strip('/')
 
         for prefix in settings.FEINCMS_ALLOW_EXTRA_PATH_PREFIX:
-            path = path.lstrip('%s/' % prefix)
+            if path.startswith('%s/' % prefix):
+                path = path[len(prefix)+1:]
 
         if path:
             tokens = path.split('/')

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -102,30 +102,6 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
 
         raise self.model.DoesNotExist
 
-
-    # def best_match_for_path(self, path, language_code=None):
-    #     """
-    #     Return the UrlNode that is the closest parent to the given path.
-    #     UrlNode.objects.best_match_for_path('/photos/album/2008/09') might return the page with url '/photos/album/'.
-    #     .. versionchanged:: 0.9 This filter only returns the pages of the current site.
-    #     """
-    #     if language_code is None:
-    #         language_code = self._language or get_language()
-
-    #     # Based on FeinCMS:
-    #     paths = self._split_path_levels(path)
-
-    #     try:
-    #         qs = self._single_site() \
-    #                  .filter(translations___cached_url__in=paths, translations__language_code=language_code) \
-    #                  .extra(select={'_url_length': 'LENGTH(_cached_url)'}) \
-    #                  .order_by('-level', '-_url_length')  # / and /news/ is both level 0
-    #         obj = qs[0]
-    #         obj.set_current_language(language_code)  # NOTE: Explicitly set language to the state the object was fetched in.
-    #         return obj
-    #     except IndexError:
-    #         raise self.model.DoesNotExist(u"No published {0} found for the path '{1}'".format(self.model.__name__, path))
-
     def in_navigation(self):
         """
         Returns active pages which have the ``in_navigation`` flag set.

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -74,12 +74,9 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
 
         paths = ['/']
         path = path.strip('/')
-        print(path)
         for prefix in settings.FEINCMS_ALLOW_EXTRA_PATH_PREFIX:
             if path.startswith('%s/' % prefix):
                 path = path[len(prefix)+1:]
-        print(path)
-
 
         if path:
             tokens = path.split('/')

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -84,8 +84,6 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
                 '/%s/' % '/'.join(tokens[:i])
                 for i in range(1, len(tokens) + 1)]
 
-        print(paths)
-
         try:
             page = self.active().filter(_cached_url__in=paths).extra(
                 select={'_url_length': 'LENGTH(_cached_url)'}

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -76,7 +76,7 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
         path = path.strip('/')
 
         for prefix in settings.FEINCMS_ALLOW_EXTRA_PATH_PREFIX:
-            path = path.lstrip(prefix).strip('/')
+            path = path.lstrip('%s/' % prefix)
 
         if path:
             tokens = path.split('/')

--- a/feincms/module/page/models.py
+++ b/feincms/module/page/models.py
@@ -74,10 +74,12 @@ class BasePageManager(ActiveAwareContentManagerMixin, TreeManager):
 
         paths = ['/']
         path = path.strip('/')
-
+        print(path)
         for prefix in settings.FEINCMS_ALLOW_EXTRA_PATH_PREFIX:
             if path.startswith('%s/' % prefix):
                 path = path[len(prefix)+1:]
+        print(path)
+
 
         if path:
             tokens = path.split('/')


### PR DESCRIPTION
I use a custom urlresolver to switch between US and Canada product lines and content, not translation based. This seems like the best way to handle this when using feincms navigation on 3rd party pages.