### PR TITLE
add Django 1.10 support (drop Django < 1.8)

### DIFF
--- a/feincms/__init__.py
+++ b/feincms/__init__.py
@@ -58,7 +58,9 @@ def ensure_completely_loaded(force=False):
     # that relations defined after all content types registrations
     # don't miss out.
     import django
-    if django.get_version() < '1.8':
+    from distutils.version import LooseVersion
+
+    if LooseVersion(django.get_version()) < LooseVersion('1.8'):
 
         for model in apps.get_models():
             for cache_name in (

--- a/feincms/content/contactform/models.py
+++ b/feincms/content/contactform/models.py
@@ -46,7 +46,7 @@ class ContactFormContent(models.Model):
         if request.GET.get('_cf_thanks'):
             self.rendered_output = render_to_string(
                 'content/contactform/thanks.html',
-                context_instance=RequestContext(request))
+                request=request)
             return
 
         if request.method == 'POST':
@@ -77,7 +77,7 @@ class ContactFormContent(models.Model):
                 'content': self,
                 'form': form,
             },
-            context_instance=RequestContext(request))
+            request=request)
 
     def render(self, **kwargs):
         return getattr(self, 'rendered_output', '')

--- a/feincms/content/file/models.py
+++ b/feincms/content/file/models.py
@@ -29,11 +29,12 @@ class FileContent(models.Model):
         verbose_name_plural = _('files')
 
     def render(self, **kwargs):
+        context = kwargs.get('context')
+        context.update({'content': self})
         return render_to_string(
             [
                 'content/file/%s.html' % self.region,
                 'content/file/default.html',
             ],
-            {'content': self},
-            context_instance=kwargs.get('context'),
+            context,
         )

--- a/feincms/content/filer/models.py
+++ b/feincms/content/filer/models.py
@@ -41,7 +41,7 @@ else:
                 'content/filer/%s.html' % self.type,
                 'content/filer/%s.html' % self.file_type,
                 'content/filer/default.html',
-            ], ctx, context_instance=kwargs.get('context'))
+            ], ctx)
 
     class FilerFileContent(ContentWithFilerFile):
         mediafile = FilerFileField(verbose_name=_('file'), related_name='+')

--- a/feincms/content/image/models.py
+++ b/feincms/content/image/models.py
@@ -59,10 +59,12 @@ class ImageContent(models.Model):
         templates = ['content/image/default.html']
         if hasattr(self, 'position'):
             templates.insert(0, 'content/image/%s.html' % self.position)
+
+        ctx = {'content': self}
+        ctx.update(kwargs)
         return render_to_string(
             templates,
-            {'content': self},
-            context_instance=kwargs.get('context'),
+            ctx,
         )
 
     def get_image(self):

--- a/feincms/content/richtext/models.py
+++ b/feincms/content/richtext/models.py
@@ -34,10 +34,11 @@ class RichTextContent(models.Model):
         verbose_name_plural = _('rich texts')
 
     def render(self, **kwargs):
+        ctx = {'content': self}
+        ctx.update(kwargs)
         return render_to_string(
             'content/richtext/default.html',
-            {'content': self},
-            context_instance=kwargs.get('context'))
+            ctx)
 
     @classmethod
     def initialize_type(cls, cleanse=None):

--- a/feincms/content/template/models.py
+++ b/feincms/content/template/models.py
@@ -33,7 +33,8 @@ class TemplateContent(models.Model):
         ))
 
     def render(self, **kwargs):
+        ctx = {'content': self}
+        ctx.update(kwargs)
         return render_to_string(
             self.template,
-            {'content': self},
-            context_instance=kwargs.get('context'))
+            ctx)

--- a/feincms/content/video/models.py
+++ b/feincms/content/video/models.py
@@ -66,9 +66,8 @@ class VideoContent(models.Model):
         return ctx
 
     def render(self, **kwargs):
-        context_instance = kwargs.get('context')
         ctx = self.ctx_for_video(self.video)
+        ctx.update(kwargs)
         return render_to_string(
             self.get_templates(ctx['portal']),
-            ctx,
-            context_instance=context_instance)
+            ctx)

--- a/feincms/contrib/fields.py
+++ b/feincms/contrib/fields.py
@@ -29,8 +29,7 @@ class JSONFormField(forms.fields.CharField):
 
         return super(JSONFormField, self).clean(value, *args, **kwargs)
 
-
-class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
+class JSONField(models.TextField):
     """
     TextField which transparently serializes/unserializes JSON objects
 
@@ -60,6 +59,9 @@ class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
         else:
             assert value is None
             return {}
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def get_prep_value(self, value):
         """Convert our JSON object to a string before we save"""

--- a/feincms/contrib/fields.py
+++ b/feincms/contrib/fields.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 import logging
+from distutils.version import LooseVersion
 
+from django import get_version
 from django import forms
 from django.db import models
 from django.core.serializers.json import DjangoJSONEncoder
@@ -29,7 +31,13 @@ class JSONFormField(forms.fields.CharField):
 
         return super(JSONFormField, self).clean(value, *args, **kwargs)
 
-class JSONField(models.TextField):
+
+if LooseVersion(get_version()) > LooseVersion('1.8'):
+    workaround_class = models.TextField
+else:
+    workaround_class = six.with_metaclass(models.SubfieldBase, models.TextField)
+
+class JSONField(workaround_class):
     """
     TextField which transparently serializes/unserializes JSON objects
 

--- a/feincms/module/medialibrary/contents.py
+++ b/feincms/module/medialibrary/contents.py
@@ -72,4 +72,4 @@ class MediaFileContent(ContentWithMediaFile):
             'content/mediafile/%s.html' % self.mediafile.type,
             'content/mediafile/%s.html' % self.type,
             'content/mediafile/default.html',
-        ], ctx, context_instance=kwargs.get('context'))
+        ], ctx)

--- a/feincms/module/medialibrary/modeladmins.py
+++ b/feincms/module/medialibrary/modeladmins.py
@@ -78,7 +78,7 @@ def assign_category(modeladmin, request, queryset):
         'mediafiles': queryset,
         'category_form': form,
         'opts': modeladmin.model._meta,
-    }, context_instance=RequestContext(request))
+    }, request=request)
 
 
 assign_category.short_description = _('Add selected media files to category')

--- a/feincms/shortcuts.py
+++ b/feincms/shortcuts.py
@@ -17,4 +17,4 @@ def render_to_response_best_match(request, template_name, dictionary=None):
     return render_to_response(
         template_name,
         dictionary,
-        context_instance=RequestContext(request))
+        request=request)

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -5,6 +5,8 @@ envlist =
     {py26,py27,py32,py33,py34}-django16,
     {py27,py33,py34}-django17,
     {py27,py34}-django18,
+    {py27,py34}-django19
+
 
 [testenv]
 commands =
@@ -15,6 +17,7 @@ deps =
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
     feedparser==5.1.3
     Pillow==2.4.0
     pytz==2014.10
@@ -24,3 +27,4 @@ deps =
     {py27,py34}-django18: django-mptt==0.7.1
     {py26,py27}-django{16,17,18}: BeautifulSoup==3.2.1
     {py32,py33,py34}-django{16,17,18}: beautifulsoup4==4.3.1
+    {py27,py34}-django{19}: django-mptt==0.8.5


### PR DESCRIPTION
PR to #636.

I ran tests for 
```
tox -e py27-django18
tox -e py27-django19
tox -e py34-django18
```
without errors:

```
Ran 58 tests in 6.574s

OK (skipped=1)
```

To keep Django <1.8 support, one could use https://github.com/arteria/django-compat/issues/38
