### PR TITLE
Added a CSS class for subitems in TreeEditor

### DIFF
--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -260,16 +260,16 @@ class TreeEditor(ExtensionModelAdmin):
         changeable_class = ''
         if not self.changeable(item):
             changeable_class = ' tree-item-not-editable'
-        subitem_class = ''
-        if item.parent:
-            subitem_class = ' tree-subitem'
+        tree_root_class = ''
+        if not item.parent:
+            tree_root_class = ' tree-root'
 
         r += (
             '<span id="page_marker-%d" class="page_marker%s%s"'
             ' style="width: %dpx;">&nbsp;</span>&nbsp;') % (
             item.pk,
             changeable_class,
-            subitem_class,
+            tree_root_class,
             14 + getattr(item, mptt_opts.level_attr) * 18)
 
 #        r += '<span tabindex="0">'

--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -260,12 +260,16 @@ class TreeEditor(ExtensionModelAdmin):
         changeable_class = ''
         if not self.changeable(item):
             changeable_class = ' tree-item-not-editable'
+        subitem_class = ''
+        if item.parent:
+            subitem_class = ' tree-subitem'
 
         r += (
-            '<span id="page_marker-%d" class="page_marker%s"'
+            '<span id="page_marker-%d" class="page_marker%s%s"'
             ' style="width: %dpx;">&nbsp;</span>&nbsp;') % (
             item.pk,
             changeable_class,
+            subitem_class,
             14 + getattr(item, mptt_opts.level_attr) * 18)
 
 #        r += '<span tabindex="0">'


### PR DESCRIPTION
I added a class to mark subitems in the TreeEditor - we needed this in our project and I felt that it was a fairly common requirement so I created a pull request. 
For the indentation it might also make sense to create classes tree-item-lvl-0 and so on instead of hard-coding the pixel values here - however one would need to enforce a maximum tree depth then, up to which css classes are provided. 