### PR TITLE
Add missing semicolons

### DIFF
--- a/feincms/templates/admin/content/richtext/init_tinymce.html
+++ b/feincms/templates/admin/content/richtext/init_tinymce.html
@@ -59,7 +59,7 @@
             $('{% block selectors %}.order-machine textarea.item-richtext{% endblock %}').each(function(){
                 feincms_richtext_add_tinymce(this);
             });
-        }
+        };
 
 			{% block enable %}
         contentblock_init_handlers.push(richtext_init_fn);

--- a/feincms/templates/admin/content/richtext/init_tinymce.html
+++ b/feincms/templates/admin/content/richtext/init_tinymce.html
@@ -55,11 +55,11 @@
                 }
         }
 
-        var richtext_init_fn = function(){
+        function richtext_init_fn() {
             $('{% block selectors %}.order-machine textarea.item-richtext{% endblock %}').each(function(){
                 feincms_richtext_add_tinymce(this);
             });
-        };
+        }
 
 			{% block enable %}
         contentblock_init_handlers.push(richtext_init_fn);

--- a/feincms/templates/admin/content/richtext/init_tinymce4.html
+++ b/feincms/templates/admin/content/richtext/init_tinymce4.html
@@ -43,12 +43,12 @@
                 }
         }
 
-        var richtext_init_fn = function(){
+        function richtext_init_fn() {
             tinyMCE.init(tinymce_options);
             $('{% block selectors %}.order-machine textarea.item-richtext{% endblock %}').each(function(){
                 feincms_richtext_add_tinymce(this);
             });
-        };
+        }
 
 			{% block enable %}
         contentblock_init_handlers.push(richtext_init_fn);

--- a/feincms/templates/admin/content/richtext/init_tinymce4.html
+++ b/feincms/templates/admin/content/richtext/init_tinymce4.html
@@ -48,7 +48,7 @@
             $('{% block selectors %}.order-machine textarea.item-richtext{% endblock %}').each(function(){
                 feincms_richtext_add_tinymce(this);
             });
-        }
+        };
 
 			{% block enable %}
         contentblock_init_handlers.push(richtext_init_fn);


### PR DESCRIPTION
Hello, I stumble onto problem when after template minification I got `SyntaxError` in the browser. It seems my minifier deleted end of line and code in browser looked like this:
```
 var richtext_init_fn = function(){
     tinyMCE.init(tinymce_options);
     $('.order-machine textarea.item-richtext').each(function(){
         feincms_richtext_add_tinymce(this);
     });
 }  contentblock_init_handlers.push(richtext_init_fn);
```

Adding semicolons fixes the issue.