### PR TITLE
docs: fix simple typo, specifiying -> specifying

### DIFF
--- a/feincms/module/page/sitemap.py
+++ b/feincms/module/page/sitemap.py
@@ -36,7 +36,7 @@ class PageSitemap(Sitemap):
         will appear in the site map.
         * max_depth -- if set to a non-negative integer, will limit the sitemap
         generated to this page hierarchy depth.
-        * changefreq -- should be a string or callable specifiying the page
+        * changefreq -- should be a string or callable specifying the page
         update frequency, according to the sitemap protocol.
         * queryset -- pass in a query set to restrict the Pages to include
         in the site map.


### PR DESCRIPTION
There is a small typo in feincms/module/page/sitemap.py.

Should read `specifying` rather than `specifiying`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md