### PR TITLE
Close image after reading dimensions.

### DIFF
--- a/feincms/module/medialibrary/modeladmins.py
+++ b/feincms/module/medialibrary/modeladmins.py
@@ -169,7 +169,7 @@ class MediaFileAdmin(ExtensionModelAdmin):
             except NotImplementedError:
                 return t
             try:
-                d = get_image_dimensions(obj.file.file)
+                d = get_image_dimensions(obj.file.file, close=True)
                 if d:
                     t += " %d&times;%d" % (d[0], d[1])
             except (OSError, TypeError, ValueError) as e:


### PR DESCRIPTION
The mediafile admin page triggers a ResourceWarning;

The warning you get to see after viewing a mediafile webpage is::

	ResourceWarning: unclosed file <_io.BufferedReader name='/***/helloworld.png'>
	ResourceWarning: Enable tracemalloc to get the object allocation traceback

Django's get_image_dimensions() leaves the file open unless you call close=True; Alternatively the admin code could do add a finally clause to the try/except and do a obj.file.close() there. But this change seems to be in the spirit of get_image_dimensions().