### PR TITLE
Use csrftoken on webpage instead of cookie.

### DIFF
--- a/feincms/static/feincms/tree_editor.js
+++ b/feincms/static/feincms/tree_editor.js
@@ -9,7 +9,7 @@ feincms.jQuery.ajaxSetup({
   crossDomain: false, // obviates need for sameOrigin test
   beforeSend(xhr, settings) {
     if (!/^(GET|HEAD|OPTIONS|TRACE)$/.test(settings.type)) {
-      xhr.setRequestHeader("X-CSRFToken", Cookies.get("csrftoken"))
+      xhr.setRequestHeader("X-CSRFToken", document.querySelector('input[name="csrfmiddlewaretoken"]').value);
     }
   },
 })


### PR DESCRIPTION
This allows the django setting CSRF_HTTP_ONLY = True.

Some sites and customers require this explicitly.