### PR TITLE
Tests failed with django-current + older python versions

### DIFF
--- a/feincms/contrib/preview/views.py
+++ b/feincms/contrib/preview/views.py
@@ -23,7 +23,6 @@ class PreviewHandler(Handler):
             return super().get_object()
 
         page = get_object_or_404(self.page_model, pk=self.args[1])
-        breakpoint()
         # Remove _preview/42/ from URL, the rest of the handler code should not
         # know that anything about previewing. Handler.prepare will still raise
         # a 404 if the extra_path isn't consumed by any content type

--- a/feincms/contrib/preview/views.py
+++ b/feincms/contrib/preview/views.py
@@ -20,7 +20,7 @@ class PreviewHandler(Handler):
         # a page that doesn't exist, and now FeinCMS wants to
         # show a 404 page via FEINCMS_CMS_404_PAGE.
         if len(self.args) < 2:
-            raise Http404("Not found (not a preview page)")
+            return super().get_object()
 
         page = get_object_or_404(self.page_model, pk=self.args[1])
         breakpoint()

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{38,39,310}-dj{32,41,42}
     py{310,311}-dj{32,41,42,50,51,52}
-    py{312}-dj{42,50,51,52,main}
+    py{312,313}-dj{42,50,51,52,main}
 
 [testenv]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
     py{38,39,310}-dj{32,41,42}
-    py{310,311}-dj{32,41,42,main}
-    py{312}-dj{42,50,51,main}
+    py{310,311}-dj{32,41,42,50,51,52}
+    py{312}-dj{42,50,51,52,main}
 
 [testenv]
 usedevelop = true
@@ -16,4 +16,5 @@ deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Fix

```
Internal Server Error: /404/

IndexError at /404/
tuple index out of range

  File "/data/django/cc.com/lib/python3.10/site-packages/feincms/module/mixins.py", line 225, in dispatch
    self.object = self.get_object()
  File "/data/django/cc.com/lib/python3.10/site-packages/feincms/contrib/preview/views.py", line 19, in get_object
    page = get_object_or_404(self.page_model, pk=self.args[1])

Exception Type: IndexError at /404/
Exception Value: tuple index out of range
Raised during: feincms.contrib.preview.views.PreviewHandler
```
