### PR TITLE
Micro-optimisation for sites with lots of pages

### DIFF
--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -419,22 +419,26 @@ class TreeEditor(ExtensionModelAdmin):
 
         extra_context = extra_context or {}
 
-        extra_context.update({
-            "tree_structure": mark_safe(
-                json.dumps(obj=_build_tree_structure(self.get_queryset(request)), separators=(",", ":"))
-            ),
-
-            "node_levels": mark_safe(
-                json.dumps(
-                    dict(
-                        self.get_queryset(request)
-                        .order_by()
-                        .values_list("pk", self.model._mptt_meta.level_attr)
-                    ),
-                    separators=(",", ":")
-                )
-            )
-        })
+        extra_context.update(
+            {
+                "tree_structure": mark_safe(
+                    json.dumps(
+                        obj=_build_tree_structure(self.get_queryset(request)),
+                        separators=(",", ":"),
+                    )
+                ),
+                "node_levels": mark_safe(
+                    json.dumps(
+                        dict(
+                            self.get_queryset(request)
+                            .order_by()
+                            .values_list("pk", self.model._mptt_meta.level_attr)
+                        ),
+                        separators=(",", ":"),
+                    )
+                ),
+            }
+        )
 
         return super().changelist_view(request, extra_context, *args, **kwargs)
 

--- a/feincms/admin/tree_editor.py
+++ b/feincms/admin/tree_editor.py
@@ -418,18 +418,23 @@ class TreeEditor(ExtensionModelAdmin):
             return HttpResponseBadRequest("Oops. AJAX request not understood.")
 
         extra_context = extra_context or {}
-        extra_context["tree_structure"] = mark_safe(
-            json.dumps(_build_tree_structure(self.get_queryset(request)))
-        )
-        extra_context["node_levels"] = mark_safe(
-            json.dumps(
-                dict(
-                    self.get_queryset(request)
-                    .order_by()
-                    .values_list("pk", self.model._mptt_meta.level_attr)
+
+        extra_context.update({
+            "tree_structure": mark_safe(
+                json.dumps(obj=_build_tree_structure(self.get_queryset(request)), separators=(",", ":"))
+            ),
+
+            "node_levels": mark_safe(
+                json.dumps(
+                    dict(
+                        self.get_queryset(request)
+                        .order_by()
+                        .values_list("pk", self.model._mptt_meta.level_attr)
+                    ),
+                    separators=(",", ":")
                 )
             )
-        )
+        })
 
         return super().changelist_view(request, extra_context, *args, **kwargs)
 

--- a/feincms/static/feincms/item_editor.js
+++ b/feincms/static/feincms/item_editor.js
@@ -4,16 +4,6 @@
 /* global id_to_windowname */
 /* global template_regions */
 
-// IE<9 lacks Array.prototype.indexOf
-if (!Array.prototype.indexOf) {
-  Array.prototype.indexOf = function (needle) {
-    for (let i = 0, l = this.length; i < l; ++i) {
-      if (this[i] === needle) return i
-    }
-    return -1
-  }
-}
-
 ;(($) => {
   // Patch up urlify maps to generate nicer slugs in german
   if (typeof Downcoder !== "undefined") {

--- a/feincms/static/feincms/tree_editor.js
+++ b/feincms/static/feincms/tree_editor.js
@@ -17,16 +17,6 @@ feincms.jQuery.ajaxSetup({
   },
 })
 
-// IE<9 lacks Array.prototype.indexOf
-if (!Array.prototype.indexOf) {
-  Array.prototype.indexOf = function (needle) {
-    for (let i = 0, l = this.length; i < l; ++i) {
-      if (this[i] === needle) return i
-    }
-    return -1
-  }
-}
-
 feincms.jQuery(($) => {
   $(document.body).on("click", "[data-inplace]", function () {
     const elem = $(this),

--- a/feincms/templates/admin/feincms/tree_editor.html
+++ b/feincms/templates/admin/feincms/tree_editor.html
@@ -7,8 +7,8 @@
 
 {% include "admin/feincms/load-jquery.include" %}
 <script type="text/javascript">
-  feincms.tree_structure = {{ tree_structure|default:"{}" }};
-  feincms.node_levels = {{ node_levels|default:"{}" }};
+  feincms.tree_structure = JSON.parse('{{ tree_structure|default:"{}" }}');
+  feincms.node_levels = JSON.parse('{{ node_levels|default:"{}" }}');
 </script>
 
 <script type="text/javascript" src="{% static 'feincms/js.cookie.js' %}"></script>


### PR DESCRIPTION
- Omit spaces in generated json
- Use JSON.parse instead of inlining JS objects
- Remove IE8 shim for indexOf